### PR TITLE
Fix typo.

### DIFF
--- a/packages/remark-lint-no-paragraph-content-indent/readme.md
+++ b/packages/remark-lint-no-paragraph-content-indent/readme.md
@@ -2,7 +2,7 @@
 
 # remark-lint-no-paragraph-content-indent
 
-Warn when warn when the content in paragraphs are indented.
+Warn when the content in paragraphs are indented.
 
 ## Presets
 


### PR DESCRIPTION
There was a typo in the no-paragraph-content-indent readme file.