### PR TITLE
Ignore inlineCode in remark-lint-maximum-line-length

### DIFF
--- a/packages/remark-lint-maximum-line-length/index.js
+++ b/packages/remark-lint-maximum-line-length/index.js
@@ -11,8 +11,7 @@
  *   Ignores nodes which cannot be wrapped, such as headings, tables,
  *   code, and definitions.
  *
- *   Ignores nodes which cannot be wrapped, such as headings, tables,
- *   code, and definitions.
+ *   Inline code is okay if it doesn't have any break point.
  *
  *   URLs in images and links are okay if they occur at or after the wrap,
  *   except when there’s white-space after them.
@@ -44,9 +43,9 @@
  *
  *   [foo]: <http://this-long-url-with-a-long-domain-is-invalid.co.uk/a-long-path?query=variables>
  *
- *   Also, inline code is fine:
+ *   Also, inline code with out break points are fine:
  *
- *   `var longLine = 'This line is simply toooooooooooooooooooooooooooooooooooooooooooo long'`
+ *   `http://this-long-url-with-a-long-domain-is-invalid.co.uk/a-long-path?query=variables`
  *
  * @example {"name": "invalid.md", "setting": 80, "label": "input", "config": {"positionless": true}}
  *
@@ -59,11 +58,14 @@
  *
  *   <http://this-long-url-with-a-long-domain-is-invalid.co.uk/a-long-path?query=variables> and such.
  *
+ *   This inline code can also have a break point `This is a loooooooong inline code with break point`.
+ *
  * @example {"name": "invalid.md", "setting": 80, "label": "output", "config": {"positionless": true}}
  *
  *   4:86: Line must be at most 80 characters
  *   6:99: Line must be at most 80 characters
  *   8:97: Line must be at most 80 characters
+ *   10:99: Line must be at most 80 characters
  *
  * @example {"name": "valid-mixed-line-endings.md", "setting": 10, "config": {"positionless": true}}
  *
@@ -112,6 +114,8 @@ function maximumLineLength(ast, file, preferred) {
 
   visit(ast, 'link', validateLink);
   visit(ast, 'image', validateLink);
+
+  visit(ast, 'inlineCode', validateInlineCode);
 
   /* Iterate over every line, and warn for
    * violating lines. */
@@ -181,6 +185,28 @@ function maximumLineLength(ast, file, preferred) {
 
     whitelist(initial.line - 1, final.line);
   }
+
+  /* Check if inline code have a break point, if it
+   * doesn’t have one, ignore it */
+  function validateInlineCode(node, pos, parent) {
+    var inlineCode = parent.children[pos].value;
+    var initial = start(node);
+    var final = end(node);
+
+    /* No whitelisting when starting after the border,
+     * or ending before it. */
+    if (initial.column > style || final.column < style) {
+      return;
+    }
+
+    /* No whitelisting when the inline code can have
+     * a break point. */
+    if (inlineCode.includes(' ')) {
+      return;
+    }
+
+    whitelist(initial.line - 1, final.line);
+  }
 }
 
 /* Check if `node` is applicable, as in, if it should be
@@ -189,6 +215,5 @@ function isIgnored(node) {
   return node.type === 'heading' ||
     node.type === 'table' ||
     node.type === 'code' ||
-    node.type === 'inlineCode' ||
     node.type === 'definition';
 }

--- a/packages/remark-lint-maximum-line-length/index.js
+++ b/packages/remark-lint-maximum-line-length/index.js
@@ -25,6 +25,8 @@
  *
  *   <http://this-link-is-fine.com>
  *
+ *   `http://also-this-link-is-fine.com`
+ *
  *   [foo](http://this-long-url-with-a-long-domain-is-valid.co.uk/a-long-path?query=variables)
  *
  *   <http://this-long-url-with-a-long-domain-is-valid.co.uk/a-long-path?query=variables>

--- a/packages/remark-lint-maximum-line-length/index.js
+++ b/packages/remark-lint-maximum-line-length/index.js
@@ -44,6 +44,10 @@
  *
  *   [foo]: <http://this-long-url-with-a-long-domain-is-invalid.co.uk/a-long-path?query=variables>
  *
+ *   Also, inline code is fine:
+ *
+ *   `var longLine = 'This line is simply toooooooooooooooooooooooooooooooooooooooooooo long'`
+ *
  * @example {"name": "invalid.md", "setting": 80, "label": "input", "config": {"positionless": true}}
  *
  *   This line is simply not tooooooooooooooooooooooooooooooooooooooooooooooooooooooo
@@ -185,5 +189,6 @@ function isIgnored(node) {
   return node.type === 'heading' ||
     node.type === 'table' ||
     node.type === 'code' ||
+    node.type === 'inlineCode' ||
     node.type === 'definition';
 }

--- a/packages/remark-lint-maximum-line-length/readme.md
+++ b/packages/remark-lint-maximum-line-length/readme.md
@@ -9,8 +9,7 @@ Options: `number`, default: `80`.
 Ignores nodes which cannot be wrapped, such as headings, tables,
 code, and definitions.
 
-Ignores nodes which cannot be wrapped, such as headings, tables,
-code, and definitions.
+Inline code is okay if it doesn't have any break point.
 
 URLs in images and links are okay if they occur at or after the wrap,
 except when there’s white-space after them.
@@ -87,6 +86,8 @@ Just like thiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiis
 And this one is also very wrong: because the link starts aaaaaaafter the column: <http://line.com>
 
 <http://this-long-url-with-a-long-domain-is-invalid.co.uk/a-long-path?query=variables> and such.
+
+This inline code can also have a break point `This is a loooooooong inline code with break point`.
 ```
 
 ###### Out
@@ -95,6 +96,7 @@ And this one is also very wrong: because the link starts aaaaaaafter the column:
 4:86: Line must be at most 80 characters
 6:99: Line must be at most 80 characters
 8:97: Line must be at most 80 characters
+10:99: Line must be at most 80 characters
 ```
 
 ##### `valid.md`
@@ -127,9 +129,9 @@ In addition, definitions are also fine:
 
 [foo]: <http://this-long-url-with-a-long-domain-is-invalid.co.uk/a-long-path?query=variables>
 
-Also, inline code is fine:
+Also, inline code with out break points are fine:
 
-`var longLine = 'This line is simply toooooooooooooooooooooooooooooooooooooooooooo long'`
+`http://this-long-url-with-a-long-domain-is-invalid.co.uk/a-long-path?query=variables`
 ```
 
 ###### Out

--- a/packages/remark-lint-maximum-line-length/readme.md
+++ b/packages/remark-lint-maximum-line-length/readme.md
@@ -126,6 +126,10 @@ The following is also fine, because there is no white-space.
 In addition, definitions are also fine:
 
 [foo]: <http://this-long-url-with-a-long-domain-is-invalid.co.uk/a-long-path?query=variables>
+
+Also, inline code is fine:
+
+`var longLine = 'This line is simply toooooooooooooooooooooooooooooooooooooooooooo long'`
 ```
 
 ###### Out

--- a/packages/remark-lint-maximum-line-length/readme.md
+++ b/packages/remark-lint-maximum-line-length/readme.md
@@ -111,6 +111,8 @@ This is also fine: <http://this-long-url-with-a-long-domain.co.uk/a-long-path?qu
 
 <http://this-link-is-fine.com>
 
+`http://also-this-link-is-fine.com`
+
 [foo](http://this-long-url-with-a-long-domain-is-valid.co.uk/a-long-path?query=variables)
 
 <http://this-long-url-with-a-long-domain-is-valid.co.uk/a-long-path?query=variables>


### PR DESCRIPTION
The inline code should be ignored, it is almost imposible to split it if the length > +80. [Here](https://github.com/nodejs/node/pull/18726/files#diff-9e8744ec73212c1966bb19fa22fc3e0aR164) is a case where splitting an inline code is not posible, or it not the best idea to do it!