### PR TITLE
[remark-lint-no-paragraph-content-indent] allow empty alt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ coverage/
 node_modules/
 remark-lint.js
 remark-lint.min.js
+yarn.lock
+package-lock.json

--- a/packages/remark-lint-no-paragraph-content-indent/index.js
+++ b/packages/remark-lint-no-paragraph-content-indent/index.js
@@ -163,7 +163,7 @@ function head(node) {
 }
 
 function applicable(node) {
-  return 'value' in node || ('alt' in node && node.alt !== null);
+  return 'value' in node || node.alt;
 }
 
 function toString(node) {

--- a/packages/remark-lint-no-paragraph-content-indent/index.js
+++ b/packages/remark-lint-no-paragraph-content-indent/index.js
@@ -104,7 +104,7 @@ function noParagraphContentIndent(tree, file) {
         return;
       }
 
-      if (first === true && ws(toString(node).charAt(0))) {
+      if (first && ws(toString(node).charAt(0))) {
         file.message(message, node.position.start);
       }
 
@@ -163,7 +163,7 @@ function head(node) {
 }
 
 function applicable(node) {
-  return 'value' in node || 'alt' in node;
+  return 'value' in node || ('alt' in node && node.alt !== null);
 }
 
 function toString(node) {

--- a/packages/remark-lint-no-paragraph-content-indent/index.js
+++ b/packages/remark-lint-no-paragraph-content-indent/index.js
@@ -32,6 +32,8 @@
  *
  *   ![image reference][] text
  *
+ *   [![][text]][text]
+ *
  * @example {"name": "invalid.md", "label": "input"}
  *
  *   ·Alpha
@@ -56,6 +58,8 @@
  *
  *   ![ image reference][] text
  *
+ *   [![ ][text]][text]
+ *
  * @example {"name": "invalid.md", "label": "output"}
  *
  *   1:1: Expected no indentation in paragraph content
@@ -67,6 +71,7 @@
  *   17:5: Expected no indentation in paragraph content
  *   19:1: Expected no indentation in paragraph content
  *   21:1: Expected no indentation in paragraph content
+ *   23:2: Expected no indentation in paragraph content
  */
 
 'use strict';

--- a/packages/remark-lint-no-paragraph-content-indent/readme.md
+++ b/packages/remark-lint-no-paragraph-content-indent/readme.md
@@ -38,6 +38,8 @@ juliett.
 ![image]() text
 
 ![image reference][] text
+
+[![][text]][text]
 ```
 
 ###### Out
@@ -72,6 +74,8 @@ Bravo
 ![ image]() text
 
 ![ image reference][] text
+
+[![ ][text]][text]
 ```
 
 ###### Out
@@ -86,6 +90,7 @@ Bravo
 17:5: Expected no indentation in paragraph content
 19:1: Expected no indentation in paragraph content
 21:1: Expected no indentation in paragraph content
+23:2: Expected no indentation in paragraph content
 ```
 
 ## Install


### PR DESCRIPTION
Fixes #172 (An exception is thrown when a image without an alt text is parsed).

`no issues found`
```md
[![][styleguide-javascript-badge]][styleguide-javascript-github]
```

`1:2  warning`
```md
[![ ][styleguide-javascript-badge]][styleguide-javascript-github]
```

`1:2  warning`
```md
[ ![][styleguide-javascript-badge]][styleguide-javascript-github]
```

## Non-issue additions
`.gitignore`
```
yarn.lock
package-lock.json
```
Running `npm i`/`yarn` resulted in 68 new `package-lock.json`'s.