### PR TITLE
Add Sublime and Grunt to list of integrations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -320,6 +320,10 @@ To run **remark**, optionally with **remark-lint** from **Gulp**, use
 
 To check markdown documents editing with Vim, use [**ale**][ale].
 
+For [**Sublime Text**](https://www.sublimetext.com) use [**SublimeLinter-contrib-remark-lint**](https://packagecontrol.io/packages/SublimeLinter-contrib-remark-lint) — part of [**SublimeLinter**](http://www.sublimelinter.com/en/stable/) framework.
+
+[**Grunt**](https://gruntjs.com/) users can use [**grunt-remark**](https://www.npmjs.com/package/grunt-remark).
+
 We’re interested in more integrations.  Let us know if we can help.
 
 ## List of Presets


### PR DESCRIPTION
### 1. Summary

I add remark integration for Sublime Text and Grunt.

### 2. Details

#### 2.1. Grunt

grunt-remark [**poorly documented**](https://www.npmjs.com/package/grunt-remark), but successfully works for me with plugins, presets and configurations.

#### 2.2. Sublime Text

See my [**pull request**](https://github.com/j616/SublimeLinter-contrib-remark-lint/pull/1), it fixes error and add support for any plugin, preset and configuration.

Thanks.