### PR TITLE
Add jest-runner-remark to integrations list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -320,6 +320,7 @@ example.md
 *   [ale][] ([Vim][]) — use remark-lint from Vim
 *   [gulp-remark][] ([Gulp][]) — use all of remark with Gulp
 *   [grunt-remark][] ([Grunt][]) — use all of remark with Grunt
+*   [jest-runner-remark][] ([Jest][]) - use all of remark with Jest
 
 We’re interested in more integrations.
 Let us know if we can help.
@@ -481,6 +482,8 @@ abide by its terms.
 
 [grunt-remark]: https://github.com/remarkjs/grunt-remark
 
+[jest-runner-remark]: https://github.com/keplersj/jest-runner-remark
+
 [ale]: https://github.com/w0rp/ale
 
 [atom]: https://atom.io
@@ -492,6 +495,8 @@ abide by its terms.
 [grunt]: https://gruntjs.com/
 
 [gulp]: https://gulpjs.com
+
+[jest]: https://jestjs.io
 
 [preset-recommended]: https://github.com/remarkjs/remark-lint/blob/master/packages/remark-preset-lint-recommended
 


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/master/support.md
https://github.com/remarkjs/.github/blob/master/contributing.md
-->
I've created a [jest-runner](https://jestjs.io/docs/en/configuration#runner-string) ([jest-runner-remark](https://github.com/keplersj/jest-runner-remark)) that checks Markdown files against remark, thought I'd share it here and hopefully in the Integrations list!