### PR TITLE
Updated validation to allow 0 as start value for ordered list

### DIFF
--- a/packages/remark-lint-ordered-list-marker-value/index.js
+++ b/packages/remark-lint-ordered-list-marker-value/index.js
@@ -147,7 +147,7 @@ function orderedListMarkerValue(tree, file, pref) {
 
   function visitor(node) {
     var children = node.children
-    var shouldBe = (pref === 'one' ? 1 : node.start) || 1
+    var shouldBe = (pref === 'one' ? 1 : node.start) || 0
     var length = node.ordered ? children.length : 0
     var index = -1
     var child

--- a/packages/remark-lint-ordered-list-marker-value/index.js
+++ b/packages/remark-lint-ordered-list-marker-value/index.js
@@ -145,9 +145,17 @@ function orderedListMarkerValue(tree, file, pref) {
 
   visit(tree, 'list', visitor)
 
+	function getStartValue(value) {
+		if (typeof value !== "undefined" && value !== null) {
+			return node.start
+		} else {
+			return 0;
+		}
+	}
+
   function visitor(node) {
     var children = node.children
-    var shouldBe = (pref === 'one' ? 1 : node.start) || 0
+    var shouldBe = pref === 'one' ? 1 : getStartValue(node.start)
     var length = node.ordered ? children.length : 0
     var index = -1
     var child

--- a/packages/remark-lint-ordered-list-marker-value/index.js
+++ b/packages/remark-lint-ordered-list-marker-value/index.js
@@ -70,6 +70,12 @@
  *   3.  Bravo
  *   3.  Charlie
  *
+ *   Paragraph.
+ *
+ *   0.  Delta
+ *   0.  Echo
+ *   0.  Foxtrot
+ *
  * @example {"name": "valid.md", "setting": "ordered"}
  *
  *   1.  Foo
@@ -81,6 +87,12 @@
  *   3.  Alpha
  *   4.  Bravo
  *   5.  Charlie
+ *
+ *   Paragraph.
+ *
+ *   0.  Delta
+ *   1.  Echo
+ *   2.  Foxtrot
  *
  * @example {"name": "invalid.md", "setting": "one", "label": "input"}
  *
@@ -147,7 +159,7 @@ function orderedListMarkerValue(tree, file, pref) {
 
   function visitor(node) {
     var children = node.children
-    var shouldBe = pref === 'one' ? 1 : (node.start == null ? 1 : node.start)
+    var shouldBe = pref === 'one' ? 1 : node.start == null ? 1 : node.start
     var length = node.ordered ? children.length : 0
     var index = -1
     var child

--- a/packages/remark-lint-ordered-list-marker-value/index.js
+++ b/packages/remark-lint-ordered-list-marker-value/index.js
@@ -145,17 +145,9 @@ function orderedListMarkerValue(tree, file, pref) {
 
   visit(tree, 'list', visitor)
 
-function getStartValue(value) {
-	if (typeof value !== "undefined" && value !== null) {
-		return value
-	} else {
-		return 0;
-	}
-}
-
   function visitor(node) {
     var children = node.children
-    var shouldBe = pref === 'one' ? 1 : getStartValue(node.start)
+    var shouldBe = pref === 'one' ? 1 : (node.start == null ? 1 : node.start)
     var length = node.ordered ? children.length : 0
     var index = -1
     var child

--- a/packages/remark-lint-ordered-list-marker-value/index.js
+++ b/packages/remark-lint-ordered-list-marker-value/index.js
@@ -145,13 +145,13 @@ function orderedListMarkerValue(tree, file, pref) {
 
   visit(tree, 'list', visitor)
 
-	function getStartValue(value) {
-		if (typeof value !== "undefined" && value !== null) {
-			return node.start
-		} else {
-			return 0;
-		}
+function getStartValue(value) {
+	if (typeof value !== "undefined" && value !== null) {
+		return value
+	} else {
+		return 0;
 	}
+}
 
   function visitor(node) {
     var children = node.children

--- a/packages/remark-lint-ordered-list-marker-value/readme.md
+++ b/packages/remark-lint-ordered-list-marker-value/readme.md
@@ -142,6 +142,12 @@ Paragraph.
 3.  Alpha
 3.  Bravo
 3.  Charlie
+
+Paragraph.
+
+0.  Delta
+0.  Echo
+0.  Foxtrot
 ```
 
 ###### Out
@@ -164,6 +170,12 @@ Paragraph.
 3.  Alpha
 4.  Bravo
 5.  Charlie
+
+Paragraph.
+
+0.  Delta
+1.  Echo
+2.  Foxtrot
 ```
 
 ###### Out


### PR DESCRIPTION
Here's small patch that allow to use 0 as start value in ordered list for https://github.com/remarkjs/remark-lint/tree/master/packages/remark-lint-ordered-list-marker-value rule.

Why is that need? Because lists like that should be valid:
```markdown
0. zero
1. one
2. two
3. three
```
but it's not with current implementation:
> Marker should be `2`, was `1`  ordered-list-marker-value  remark-lint

[Example](https://astexplorer.net/#/gist/aee4106f9fbb2bd58f7bd1af2cba13fb/f296549aebf441f0fac64885a0e4213571da40d7)

I'm working now on remark lint preset for Gatsby docs and faced with this issue here:
![image](https://user-images.githubusercontent.com/28801003/67288213-39727000-f4e5-11e9-9a8b-9c1099e5cfd5.png)

That's not a BREAKING CHANGE and tests seems okay