### PR TITLE
maximum-line-length: ignore `yaml`, `toml`

### DIFF
--- a/packages/remark-lint-maximum-line-length/index.js
+++ b/packages/remark-lint-maximum-line-length/index.js
@@ -111,7 +111,11 @@ function maximumLineLength(tree, file, option) {
   var lineLength
 
   // Note: JSX is from MDX: <https://github.com/mdx-js/specification>.
-  visit(tree, ['heading', 'table', 'code', 'definition', 'html', 'jsx'], ignore)
+  visit(
+    tree,
+    ['heading', 'table', 'code', 'definition', 'html', 'jsx', 'yaml'],
+    ignore
+  )
   visit(tree, ['link', 'image', 'inlineCode'], inline)
 
   // Iterate over every line, and warn for violating lines.

--- a/packages/remark-lint-maximum-line-length/index.js
+++ b/packages/remark-lint-maximum-line-length/index.js
@@ -113,7 +113,7 @@ function maximumLineLength(tree, file, option) {
   // Note: JSX is from MDX: <https://github.com/mdx-js/specification>.
   visit(
     tree,
-    ['heading', 'table', 'code', 'definition', 'html', 'jsx', 'yaml'],
+    ['heading', 'table', 'code', 'definition', 'html', 'jsx', 'yaml', 'toml'],
     ignore
   )
   visit(tree, ['link', 'image', 'inlineCode'], inline)


### PR DESCRIPTION
https://spectrum.chat/unified/remark/excluding-frontmatter-from-remark-lint-rules~fbe35244-c33d-4f97-bf21-b15c196a52a3

<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->
