### PR TITLE
no-duplicate-headings-in-section: fix missing warning on depth-jump

### DIFF
--- a/packages/remark-lint-no-duplicate-headings-in-section/index.js
+++ b/packages/remark-lint-no-duplicate-headings-in-section/index.js
@@ -39,15 +39,19 @@
  *
  * @example {"name": "not-ok-tolerant-heading-increment.md", "label": "input"}
  *
- *   # Foxtrot
+ *   # Alpha
  *
- *   #### Golf
+ *   #### Bravo
  *
- *   #### Golf
+ *   ###### Charlie
+ *
+ *   #### Bravo
+ *
+ *   ###### Delta
  *
  * @example {"name": "not-ok-tolerant-heading-increment.md", "label": "output"}
  *
- *   5:1-5:10: Do not use headings with similar content per section (3:1)
+ *   7:1-7:11: Do not use headings with similar content per section (3:1)
  */
 
 'use strict'
@@ -73,20 +77,19 @@ function noDuplicateHeadingsInSection(tree, file) {
 
   function visitor(node) {
     var depth = node.depth
-    var index = depth - 1
     var value = toString(node).toUpperCase()
+    var index = depth - 1
+    var scope = stack[index] || (stack[index] = {})
+    var duplicate = scope[value]
 
-    stack = stack.slice(0, depth)
-    if (!stack[index]) stack[index] = {}
-
-    var possibleDuplicate = stack[index][value]
-    if (!generated(node) && possibleDuplicate && possibleDuplicate.type === 'heading') {
+    if (!generated(node) && duplicate) {
       file.message(
-        reason + ' (' + stringify(position.start(possibleDuplicate)) + ')',
+        reason + ' (' + stringify(position.start(duplicate)) + ')',
         node
       )
     }
 
-    stack[index][value] = node
+    scope[value] = node
+    stack = stack.slice(0, depth)
   }
 }

--- a/test.js
+++ b/test.js
@@ -261,9 +261,6 @@ test('rules', function (t) {
   var root = path.join(process.cwd(), 'packages')
   var all = rules(root)
 
-  // TODO: Remove next line
-  all = ["remark-lint-no-duplicate-headings-in-section"]
-
   t.plan(all.length)
 
   all.forEach(each)

--- a/test.js
+++ b/test.js
@@ -261,6 +261,9 @@ test('rules', function (t) {
   var root = path.join(process.cwd(), 'packages')
   var all = rules(root)
 
+  // TODO: Remove next line
+  all = ["remark-lint-no-duplicate-headings-in-section"]
+
   t.plan(all.length)
 
   all.forEach(each)


### PR DESCRIPTION
👋 First of all, sry for not opening an issue first – I was not sure if it's a bug or by design, then I wrote a test to verify my issue and then I was too curious about the codebase to resist tinkering with it :) 🤓 

---

**Current behavior:**

`remark-lint-no-duplicate-headings-in-section` doesn't detect duplicate headings when those headings are not sequentially incremented.

```
# Alpha

## Beta

## Beta // detected

#### Charlie // note heading level 4, not level 3

#### Charlie // not detected
```

**Proposed behavior:** 
👀 but not sure if it should be like this by default, or with an option

Duplicate headings in sections should be detected even when they are not sequentially incremented.
Maybe better explained in the test.