### PR TITLE
unified-lint-rule: allow vFile.message() overwrite the ruleId and source

### DIFF
--- a/packages/unified-lint-rule/index.js
+++ b/packages/unified-lint-rule/index.js
@@ -47,8 +47,8 @@ function factory(id, rule) {
 
         while (index < messages.length) {
           message = messages[index]
-          message.ruleId = ruleId
-          message.source = source
+          if(!message.ruleId){ message.ruleId = ruleId }
+          if(!message.source){ message.source = source }
           message.fatal = fatal
 
           index++


### PR DESCRIPTION
## Example

i can file a message to a `vFile` with the `.message`, where the third parameter is the `ruleId:string`, but this this `ruleId` is replaced by `unified-lint-rule`

```javascript
module.exports = rule('remark-lint:my-rule', myRule);
//...
const message = file.message(`my message`, position, `remark-lint:my-rule:${subRuleId}`);

//or
const message = file.message(`my message`, position, `my-rule:${subRuleId}`);
```

so i can also give parameters to the messages like the ones provided by retext where the rules are in the format: `retext-spell:${word}`

## Solution

with the proposed change the custom rule from the `.message()` is preserved