### PR TITLE
Allow comments within EOF link definition set

### DIFF
--- a/packages/remark-lint-final-definition/index.js
+++ b/packages/remark-lint-final-definition/index.js
@@ -46,7 +46,7 @@ function finalDefinition(tree, file) {
     var line = start(node).line
 
     // Ignore generated nodes.
-    if (node.type === 'root' || generated(node)) {
+    if (node.type === 'root' || generated(node) || /^\s*<!--/.test(node.value)) {
       return
     }
 


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->

The `final-definition` rule throws errors when comments are inserted between definitions. This commit adds a check to return the node validator function early for comments, essentially ignoring them for the purposes of this rule (making sure all definitions are listed together at the EOF).

Closes GH-244