### PR TITLE
Add `remark-lint-strikethrough-marker`

### DIFF
--- a/doc/rules.md
+++ b/doc/rules.md
@@ -132,6 +132,7 @@ Rules][external].
 *   [`ordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-style) — warn when the markers of ordered lists violate a given style
 *   [`ordered-list-marker-value`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-value) — warn when the marker value of ordered lists violates a given style
 *   [`rule-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-rule-style) — warn when horizontal rules violate a given style
+*   [`strikethrough-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-strikethrough-marker) — warn when strikethrough markers violate the given style
 *   [`strong-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-strong-marker) — warn when importance (strong) markers violate the given style
 *   [`table-cell-padding`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-table-cell-padding) — warn when table cells are incorrectly padded
 *   [`table-pipe-alignment`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-table-pipe-alignment) — warn when table pipes are not aligned

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "David Clark <dclark@mapbox.com>",
     "Саша Черных <SashaChernykhEmpressOfUniverse@kristinita.ru>",
     "Bob “Wombat” Hogg <wombat@rwhogg.site>",
-    "David Chambers <dc@davidchambers.me>"
+    "David Chambers <dc@davidchambers.me>",
+    "Denis Augsburger <denis.augsburger@simpleen.io> (https://simpleen.io)"
   ],
   "devDependencies": {
     "browserify": "^17.0.0",

--- a/packages/remark-lint-strikethrough-marker/index.js
+++ b/packages/remark-lint-strikethrough-marker/index.js
@@ -1,0 +1,103 @@
+/**
+ * @author Denis Augsburger
+ * @copyright 2021 Denis Augsburger
+ * @license MIT
+ * @module strikethrough-marker
+ * @fileoverview
+ *   Warn for violating strikethrough markers.
+ *
+ *   Options: `'consistent'`, `'~'`, or `'~~'`, default: `'consistent'`.
+ *
+ *   `'consistent'` detects the first used strikethrough style and warns when
+ *   subsequent strikethrough use different styles.
+ *
+ *   ## Fix
+ *
+ *   See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)
+ *   on how to automatically fix warnings for this rule.
+ *
+ * @example {"setting": "~", "name": "ok.md"}
+ *
+ *   ~foo~
+ *
+ * @example {"setting": "~", "name": "not-ok.md", "label": "input"}
+ *
+ *   ~~foo~~
+ *
+ * @example {"setting": "~", "name": "not-ok.md", "label": "output"}
+ *
+ *   1:1-1:6: Strikethrough should use `~` as a marker
+ *
+ * @example {"setting": "~~", "name": "ok.md"}
+ *
+ *   ~~foo~~
+ *
+ * @example {"setting": "~~", "name": "not-ok.md", "label": "input"}
+ *
+ *   ~foo~
+ *
+ * @example {"setting": "~~", "name": "not-ok.md", "label": "output"}
+ *
+ *   1:1-1:6: Strikethrough should use `~~` as a marker
+ *
+ * @example {"name": "not-ok.md", "label": "input"}
+ *
+ *   ~~foo~~
+ *   ~bar~
+ *
+ * @example {"name": "not-ok.md", "label": "output"}
+ *
+ *   2:1-2:6: Strikethrough should use `~~` as a marker
+ *
+ * @example {"setting": "💩", "name": "not-ok.md", "label": "output", "positionless": true}
+ *
+ *   1:1: Incorrect strikethrough marker `💩`: use either `'consistent'`, `'~'`, or `'~~'`
+ */
+
+'use strict'
+
+var rule = require('unified-lint-rule')
+var visit = require('unist-util-visit')
+var position = require('unist-util-position')
+var generated = require('unist-util-generated')
+
+module.exports = rule('remark-lint:strikethrough-marker', strikethroughMarker)
+
+var markers = {null: true, '~': true, '~~': true}
+
+function strikethroughMarker(tree, file, option) {
+  var contents = String(file)
+  var preferred =
+    typeof option === 'string' && option !== 'consistent' ? option : null
+
+  if (markers[preferred] !== true) {
+    file.fail(
+      'Incorrect strikethrough marker `' +
+        preferred +
+        "`: use either `'consistent'`, `'~'`, or `'~~'`"
+    )
+  }
+
+  visit(tree, 'delete', visitor)
+
+  function visitor(node) {
+    var marker
+
+    if (!generated(node)) {
+      marker = contents.substr(position.start(node).offset, 2) === '~~' ? 
+        contents.substr(position.start(node).offset, 2) :
+        contents.substr(position.start(node).offset, 1)
+
+      if (preferred) {
+        if (marker !== preferred) {
+          file.message(
+            'Strikethrough should use `' + preferred + '` as a marker',
+            node
+          )
+        }
+      } else {
+        preferred = marker
+      }
+    }
+  }
+}

--- a/packages/remark-lint-strikethrough-marker/index.js
+++ b/packages/remark-lint-strikethrough-marker/index.js
@@ -16,40 +16,40 @@
  *   See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)
  *   on how to automatically fix warnings for this rule.
  *
- * @example {"setting": "~", "name": "ok.md"}
+ * @example {"setting": "~", "name": "ok.md", "gfm": true}
  *
  *   ~foo~
  *
- * @example {"setting": "~", "name": "not-ok.md", "label": "input"}
+ * @example {"setting": "~", "name": "not-ok.md", "label": "input", "gfm": true}
  *
  *   ~~foo~~
  *
- * @example {"setting": "~", "name": "not-ok.md", "label": "output"}
+ * @example {"setting": "~", "name": "not-ok.md", "label": "output", "gfm": true}
  *
- *   1:1-1:6: Strikethrough should use `~` as a marker
+ *   1:1-1:8: Strikethrough should use `~` as a marker
  *
- * @example {"setting": "~~", "name": "ok.md"}
+ * @example {"setting": "~~", "name": "ok.md", "gfm": true}
  *
  *   ~~foo~~
  *
- * @example {"setting": "~~", "name": "not-ok.md", "label": "input"}
+ * @example {"setting": "~~", "name": "not-ok.md", "label": "input", "gfm": true}
  *
  *   ~foo~
  *
- * @example {"setting": "~~", "name": "not-ok.md", "label": "output"}
+ * @example {"setting": "~~", "name": "not-ok.md", "label": "output", "gfm": true}
  *
  *   1:1-1:6: Strikethrough should use `~~` as a marker
  *
- * @example {"name": "not-ok.md", "label": "input"}
+ * @example {"name": "not-ok.md", "label": "input", "gfm": true}
  *
  *   ~~foo~~
  *   ~bar~
  *
- * @example {"name": "not-ok.md", "label": "output"}
+ * @example {"name": "not-ok.md", "label": "output", "gfm": true}
  *
  *   2:1-2:6: Strikethrough should use `~~` as a marker
  *
- * @example {"setting": "💩", "name": "not-ok.md", "label": "output", "positionless": true}
+ * @example {"setting": "💩", "name": "not-ok.md", "label": "output", "positionless": true, "gfm": true}
  *
  *   1:1: Incorrect strikethrough marker `💩`: use either `'consistent'`, `'~'`, or `'~~'`
  */
@@ -84,9 +84,11 @@ function strikethroughMarker(tree, file, option) {
     var marker
 
     if (!generated(node)) {
-      marker = contents.substr(position.start(node).offset, 2) === '~~' ? 
-        contents.substr(position.start(node).offset, 2) :
-        contents.substr(position.start(node).offset, 1)
+      var offset = position.start(node).offset
+      marker =
+        contents.slice(offset, offset + 2) === '~~'
+          ? contents.slice(offset, offset + 2)
+          : contents.slice(offset, offset + 1)
 
       if (preferred) {
         if (marker !== preferred) {

--- a/packages/remark-lint-strikethrough-marker/package.json
+++ b/packages/remark-lint-strikethrough-marker/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "remark-lint-strikethrough-marker",
+  "version": "2.0.1",
+  "description": "remark-lint rule to warn when strikethrough markers violate the given style",
+  "license": "MIT",
+  "keywords": [
+    "remark",
+    "lint",
+    "rule",
+    "remark-lint-rule",
+    "strikethrough",
+    "marker"
+  ],
+  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-strikethrough-marker",
+  "bugs": "https://github.com/remarkjs/remark-lint/issues",
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/unified"
+  },
+  "author": "Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)",
+  "contributors": [
+    "Denis Augsburger <denis.augsburger@simpleen.io> (https://simpleen.io)",
+    "Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)"
+  ],
+  "files": [
+    "index.js"
+  ],
+  "dependencies": {
+    "unified-lint-rule": "^1.0.0",
+    "unist-util-generated": "^1.1.0",
+    "unist-util-position": "^3.0.0",
+    "unist-util-visit": "^2.0.0"
+  },
+  "xo": false
+}

--- a/packages/remark-lint-strikethrough-marker/readme.md
+++ b/packages/remark-lint-strikethrough-marker/readme.md
@@ -1,0 +1,213 @@
+<!--This file is generated-->
+
+# remark-lint-strikethrough-marker
+
+[![Build][build-badge]][build]
+[![Coverage][coverage-badge]][coverage]
+[![Downloads][downloads-badge]][downloads]
+[![Size][size-badge]][size]
+[![Sponsors][sponsors-badge]][collective]
+[![Backers][backers-badge]][collective]
+[![Chat][chat-badge]][chat]
+
+Warn for violating strikethrough markers.
+
+Options: `'consistent'`, `'~'`, or `'~~'`, default: `'consistent'`.
+
+`'consistent'` detects the first used strikethrough style and warns when
+subsequent strikethrough use different styles.
+
+## Fix
+
+See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)
+on how to automatically fix warnings for this rule.
+
+## Presets
+
+This rule is not included in any default preset
+
+## Example
+
+##### `ok.md`
+
+When configured with `'~'`.
+
+###### In
+
+```markdown
+~foo~
+```
+
+###### Out
+
+No messages.
+
+##### `not-ok.md`
+
+When configured with `'~'`.
+
+###### In
+
+```markdown
+~~foo~~
+```
+
+###### Out
+
+```text
+1:1-1:6: Strikethrough should use `~` as a marker
+```
+
+##### `ok.md`
+
+When configured with `'~~'`.
+
+###### In
+
+```markdown
+~~foo~~
+```
+
+###### Out
+
+No messages.
+
+##### `not-ok.md`
+
+When configured with `'~~'`.
+
+###### In
+
+```markdown
+~foo~
+```
+
+###### Out
+
+```text
+1:1-1:6: Strikethrough should use `~~` as a marker
+```
+
+##### `not-ok.md`
+
+###### In
+
+```markdown
+~~foo~~
+~bar~
+```
+
+###### Out
+
+```text
+2:1-2:6: Strikethrough should use `~~` as a marker
+```
+
+##### `not-ok.md`
+
+When configured with `'💩'`.
+
+###### Out
+
+```text
+1:1: Incorrect strikethrough marker `💩`: use either `'consistent'`, `'~'`, or `'~~'`
+```
+
+## Install
+
+[npm][]:
+
+```sh
+npm install remark-lint-strikethrough-marker
+```
+
+## Use
+
+You probably want to use it on the CLI through a config file:
+
+```diff
+ …
+ "remarkConfig": {
+   "plugins": [
+     …
+     "lint",
++    "lint-strikethrough-marker",
+     …
+   ]
+ }
+ …
+```
+
+Or use it on the CLI directly
+
+```sh
+remark -u lint -u lint-strikethrough-marker readme.md
+```
+
+Or use this on the API:
+
+```diff
+ var remark = require('remark')
+ var report = require('vfile-reporter')
+
+ remark()
+   .use(require('remark-lint'))
++  .use(require('remark-lint-strikethrough-marker'))
+   .process('_Emphasis_ and **importance**', function (err, file) {
+     console.error(report(err || file))
+   })
+```
+
+## Contribute
+
+See [`contributing.md`][contributing] in [`remarkjs/.github`][health] for ways
+to get started.
+See [`support.md`][support] for ways to get help.
+
+This project has a [code of conduct][coc].
+By interacting with this repository, organization, or community you agree to
+abide by its terms.
+
+## License
+
+[MIT][license] © [Titus Wormer][author]
+
+[build-badge]: https://github.com/remarkjs/remark-lint/workflows/main/badge.svg
+
+[build]: https://github.com/remarkjs/remark-lint/actions
+
+[coverage-badge]: https://img.shields.io/codecov/c/github/remarkjs/remark-lint.svg
+
+[coverage]: https://codecov.io/github/remarkjs/remark-lint
+
+[downloads-badge]: https://img.shields.io/npm/dm/remark-lint-strikethrough-marker.svg
+
+[downloads]: https://www.npmjs.com/package/remark-lint-strikethrough-marker
+
+[size-badge]: https://img.shields.io/bundlephobia/minzip/remark-lint-strikethrough-marker.svg
+
+[size]: https://bundlephobia.com/result?p=remark-lint-strikethrough-marker
+
+[sponsors-badge]: https://opencollective.com/unified/sponsors/badge.svg
+
+[backers-badge]: https://opencollective.com/unified/backers/badge.svg
+
+[collective]: https://opencollective.com/unified
+
+[chat-badge]: https://img.shields.io/badge/chat-discussions-success.svg
+
+[chat]: https://github.com/remarkjs/remark/discussions
+
+[npm]: https://docs.npmjs.com/cli/install
+
+[health]: https://github.com/remarkjs/.github
+
+[contributing]: https://github.com/remarkjs/.github/blob/HEAD/contributing.md
+
+[support]: https://github.com/remarkjs/.github/blob/HEAD/support.md
+
+[coc]: https://github.com/remarkjs/.github/blob/HEAD/code-of-conduct.md
+
+[license]: https://github.com/remarkjs/remark-lint/blob/main/license
+
+[author]: https://wooorm.com

--- a/packages/remark-lint-strikethrough-marker/readme.md
+++ b/packages/remark-lint-strikethrough-marker/readme.md
@@ -34,6 +34,8 @@ When configured with `'~'`.
 
 ###### In
 
+Note: this example uses [GFM][].
+
 ```markdown
 ~foo~
 ```
@@ -48,6 +50,8 @@ When configured with `'~'`.
 
 ###### In
 
+Note: this example uses [GFM][].
+
 ```markdown
 ~~foo~~
 ```
@@ -55,7 +59,7 @@ When configured with `'~'`.
 ###### Out
 
 ```text
-1:1-1:6: Strikethrough should use `~` as a marker
+1:1-1:8: Strikethrough should use `~` as a marker
 ```
 
 ##### `ok.md`
@@ -63,6 +67,8 @@ When configured with `'~'`.
 When configured with `'~~'`.
 
 ###### In
+
+Note: this example uses [GFM][].
 
 ```markdown
 ~~foo~~
@@ -78,6 +84,8 @@ When configured with `'~~'`.
 
 ###### In
 
+Note: this example uses [GFM][].
+
 ```markdown
 ~foo~
 ```
@@ -91,6 +99,8 @@ When configured with `'~~'`.
 ##### `not-ok.md`
 
 ###### In
+
+Note: this example uses [GFM][].
 
 ```markdown
 ~~foo~~
@@ -211,3 +221,5 @@ abide by its terms.
 [license]: https://github.com/remarkjs/remark-lint/blob/main/license
 
 [author]: https://wooorm.com
+
+[gfm]: https://github.com/remarkjs/remark-gfm


### PR DESCRIPTION
I've used the emphasis linting example and implemented it pretty similar for the strikethrough rule.

I didn't get how the tests are generated/handled from the comments. There are 3 errors corresponding to the new package. 
How can I fix these?

<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->
