### PR TITLE
Add documentation for creating custom rules. Closes #261

### DIFF
--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -192,8 +192,8 @@ function noGifAllowed(tree, file, options) {
        // This is an extremely simplified example of how to structure
        // the logic to check whether a node violates your rule.
        // You have complete freedom over how to visit/inspect the tree,
-       //and on how to implement the validation logic for your node.
-      const isValid = isValidNode(node);
+       // and on how to implement the validation logic for your node.
+      const isValid = isValidNode(node)
       if (!isValid) {
         // Remember to provide the node as second argument to the message,
         // in order to obtain the position and column where the violation occurred.

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -34,7 +34,7 @@ npm install remark-lint remark-cli
 *   [`remark-lint`](https://github.com/remarkjs/remark-lint): Core lint plugin
 *   [`remark-cli`](https://github.com/remarkjs/remark/tree/main/packages/remark-cli): Command-line interface
 
-We will also need some utilities:
+We will also use some utilities:
 
 ```sh
 npm install unified-lint-rule unist-util-generated unist-util-visit

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -154,7 +154,7 @@ This can help you when wanting to create a group of rules under the same *namesp
 
 ## Rule arguments
 
-Your rule function will receive three arguments.
+Your rule function will receive three arguments:
 
 ```js
 function noGifAllowed(tree, file, options) {}

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -28,7 +28,7 @@ npm init -y
 Now we can start installing our dependencies:
 
 ```sh
- npm install remark-lint remark-cli
+npm install remark-lint remark-cli
 ```
 
 *   [`remark-lint`](https://github.com/remarkjs/remark-lint): Core lint plugin

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -13,7 +13,7 @@ This tutorial will help you creating your first linting plugin for `remark`.
 *   [Import the rule in your remark config](#import-the-rule-in-your-remark-config)
 *   [Apply the rule on the Markdown file](#apply-the-rule-on-the-markdown-file)
 
-\## Set up the project
+## Set up the project
 
 Create a new folder and navigate inside it from your Terminal. For this example I will be using UNIX commands (macOS and Linux compatible).
 Now we can generate our `package.json`

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -143,9 +143,9 @@ Let’s say you want all your custom rules to be defined as part of your project
 If your project was named `my-project`, then you can export your rule as:
 
 ```js
-module.exports = rule("my-project-name:no-gif-allowed", noGifAllowed);
-// or
-module.exports = rule("my-npm-published-package:no-gif-allowed", noGifAllowed);
+module.exports = rule('my-project-name:no-gif-allowed', noGifAllowed)
+// Or:
+module.exports = rule('my-npm-published-package:no-gif-allowed', noGifAllowed)
 ```
 
 This can help you when wanting to create a group of rules under the same *namespace*.

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -125,7 +125,7 @@ cd .. # return to project root
 
 *Note*: the name of folders and files, and where to place them within your project, is up to you.
 
-In `./rules/no-gif-allowed.js`, let's import `unified-lint-rule`.
+In `./rules/no-gif-allowed.js`, let’s import `unified-lint-rule`.
 
 We then export the result of calling `rule` by providing the *namespace and rule name* (`remark-lint:no-gif-allowed`) as the first argument, and our implementation of the rule (`noGifAllowed`) as the second argument.
 

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -198,9 +198,9 @@ function noGifAllowed(tree, file, options) {
         // Remember to provide the node as second argument to the message,
         // in order to obtain the position and column where the violation occurred.
         file.message(
-          `Invalid image file extentions. Please do not use gifs`,
+          'Invalid image file extentions. Please do not use gifs',
           node
-        );
+        )
       }
     }
   }

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -213,7 +213,7 @@ module.exports = rule("remark-lint:no-gif-allowed", noGifAllowed);
 
 ## Import the rule in your remark config
 
-Now that our custom rule is defined, and ready to be used, we need to add it to our `remark` configuration.
+Now that our custom rule is defined and ready to be used we need to add it to our `remark` configuration.
 
 You can do that by importing your rule and adding it in `plugins` array:
 

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -13,8 +13,6 @@ This tutorial will help you creating your first linting plugin for `remark`.
 *   [Import the rule in your remark config](#import-the-rule-in-your-remark-config)
 *   [Apply the rule on the Markdown file](#apply-the-rule-on-the-markdown-file)
 
-Fork this [repository](https://github.com/floroz/blog-posts/tree/main/how-to-create-custom-lint-rule-markdown-mdx) with the complete tutorial, if you don't want to start from scratch.
-
 \## Set up the project
 
 Create a new folder and navigate inside it from your Terminal. For this example I will be using UNIX commands (macOS and Linux compatible).

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -181,8 +181,8 @@ function isValidNode(node) {
   // Here we check whether the given node violates our rule.
   // Implementation details are not relevant to the scope of this example.
   // This is an overly simplified solution for demonstration purposes
-  if (node.url && typeof node.url === "string") {
-    return !node.url.endsWith(".gif");
+  if (node.url && typeof node.url === 'string') {
+    return !node.url.endsWith('.gif')
   }
 }
 function noGifAllowed(tree, file, options) {

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -122,6 +122,7 @@ Let's create a new folder `rules` under the root directory, where we will place 
 $ mkdir rules
 $ cd rules
 $ touch no-gif-allowed.js
+$ cd .. # return to project root
 ```
 
 *Remember*: the name of the folder and files, and where to place them within your project, is entirely up to you.

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -72,7 +72,7 @@ Then, in our `package.json`, add the following script to process all the markdow
 Let’s create a `doc.md`, the markdown file we want to lint:
 
 ```sh
- touch doc.md
+touch doc.md
 ```
 
 ...and copy/paste the following:

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -1,6 +1,6 @@
 # Create a custom `remark-lint` rule
 
-This tutorial will help you creating your first linting plugin for `remark`.
+This guide is part of [a step-by-step tutorial](https://dev.to/floroz/how-to-create-a-custom-lint-rule-for-markdown-and-mdx-using-remark-and-eslint-2jim), and will help you getting started to create your first linting plugin for `remark`.
 
 ## Table of Contents
 

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -37,7 +37,7 @@ Now we can start installing our dependencies:
 We will also need some utilities:
 
 ```sh
- npm install unified-lint-rule unist-util-generated unist-util-visit
+npm install unified-lint-rule unist-util-generated unist-util-visit
 ```
 
 These will help us creating and managing our custom rules.

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -2,7 +2,8 @@
 
 This tutorial will help you setting up a JavaScript project, and creating your first linting plugin for `remark`.
 
-## Table of Contents
+### Table of Contents
+
 *   [Set up the project](#set-up-the-project)
 *   [Set up remark](#set-up-remark)
 *   [The no-invalid-gif rule:](#the-no-invalid-gif-rule)
@@ -12,7 +13,7 @@ This tutorial will help you setting up a JavaScript project, and creating your f
 *   [Import the rule in your remark config](#import-the-rule-in-your-remark-config)
 *   [Apply the rule](#apply-the-rule)
 
-### Set up the project
+\## Set up the project
 
 Let's set up the project and start adding our dependencies.
 
@@ -38,7 +39,7 @@ yarn unified-lint-rule unist-util-generated unist-util-visit
 
 These will help us creating and managing our custom rules.
 
-### Set up remark
+## Set up remark
 
 With our dependencies all installed, we can start creating a `.remarkrc.js`, which will contain all the plugins that will be consumed by the remark processor.
 For details about alternative or advanced configurations, please refer to [Configuring remark-lint](https://github.com/remarkjs/remark-lint#configuring-remark-lint).
@@ -81,7 +82,7 @@ doc.md: no issues found
 
 All good, the file has been processed, and because we haven't specified any plugins nor lint rule, no issues are found.
 
-### The no-invalid-gif rule
+## The no-invalid-gif rule
 
 Let's imagine we want to write a rule that checks whether a `.gif` file is used within an image.
 
@@ -99,7 +100,7 @@ Some funny images of our favourite pets
 
 We would expect an *error* or *warning* pointing to `funny-cat.gif`, because the file extension `.gif` violates our rule.
 
-### Create the custom rule
+## Create the custom rule
 
 Let's create a new folder `rules` under the root directory, where we will place all of our custom rules, and create a new file in it named `no-gif-allowed.js`.
 
@@ -126,7 +127,7 @@ module.exports = rule("my-project:no-gif-allowed", noGifAllowed);
 
 This can help you when wanting to create a group of rules under the same *label* or *namespace*.
 
-### Rule arguments
+## Rule arguments
 
 Your rule function will receive three arguments.
 
@@ -138,7 +139,7 @@ function noGifAllowed(tree, file, options) {}
 *   `file` (*required*): a [virtual file format](https://github.com/vfile/vfile).
 *   `options` (*optional*): additional information passed to the rule by the remark plugins definition.
 
-### Rule implementation
+## Rule implementation
 
 Because we will be inspecting a [mdast](https://github.com/syntax-tree/mdast), which is a markdown abstract syntax tree built upon [unist](https://github.com/syntax-tree/unist), we can take advantage of the many existing [unist utilities](https://github.com/syntax-tree/unist#utilities) to inspect our tree's nodes.
 
@@ -182,7 +183,7 @@ function noGifAllowed(tree, file, options) {
 module.exports = rule("remark-lint:no-gif-allowed", noGifAllowed);
 ```
 
-### Import the rule in your remark config
+## Import the rule in your remark config
 
 Now that our custom rule is defined, and ready to be used, we need to add it to our `remark` configuration.
 
@@ -197,7 +198,7 @@ module.exports = {
 };
 ```
 
-### Apply the rule
+## Apply the rule
 
 If you run `yarn lint`, you should see the following message in the terminal:
 

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -15,7 +15,8 @@ This guide is part of [a step-by-step tutorial](https://dev.to/floroz/how-to-cre
 
 ## Set up the project
 
-Create a new folder and enter it from your terminal. For this example I will be using Unix commands (macOS and Linux compatible).
+Create a new folder and enter it from your terminal.
+For this example I will be using Unix commands (macOS and Linux compatible).
 Now we can generate our `package.json`
 
 ```sh

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -2,6 +2,17 @@
 
 The following is a short guide on how to setup a JavaScript project and create a linting plugin for `remark` using `remark-lint`.
 
+## Table of Contents
+
+* [Set up the project](#1-set-up-the-project)
+* [Set up remark](#2-set-up-remark)
+* [The no-invalid-gif rule](#3-the-no-invalid-gif-rule)
+* [Create the custom rule](#4-create-the-custom-rule)
+* [Rule arguments](#5-rule-arguments)
+* [Rule implementation](#6-rule-implementation)
+* [Import the rule in your remark config](#7-import-the-rule-in-your-remark-config)
+* [Apply the rule](#8-apply-the-rule)
+
 
 ### 1. Set up the project
 
@@ -72,7 +83,7 @@ doc.md: no issues found
 
 All good, the file has been processed, and because we haven't specified any plugins nor lint rule, no issues are found.
 
-### 3. The `no-invalid-gif` rule:
+### 3. The no-invalid-gif rule:
 
 Let's imagine we want to write a rule that checks whether a `.gif` file is used within an image.
 
@@ -188,7 +199,7 @@ module.exports = {
 };
 ```
 
-### 8. Run the linter
+### 8. Apply the rule
 
 If you run `yarn lint`, you should see the following message in the terminal:
 

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -2,7 +2,7 @@
 
 This guide is part of [a step-by-step tutorial](https://dev.to/floroz/how-to-create-a-custom-lint-rule-for-markdown-and-mdx-using-remark-and-eslint-2jim), and will help you getting started to create your first linting plugin for `remark`.
 
-## Table of Contents
+## Contents
 
 *   [Set up the project](#set-up-the-project)
 *   [Set up remark](#set-up-remark)
@@ -15,43 +15,44 @@ This guide is part of [a step-by-step tutorial](https://dev.to/floroz/how-to-cre
 
 ## Set up the project
 
-Create a new folder and navigate inside it from your Terminal. For this example I will be using UNIX commands (macOS and Linux compatible).
+Create a new folder and enter it from your terminal. For this example I will be using Unix commands (macOS and Linux compatible).
 Now we can generate our `package.json`
 
-```bash
-$ mkdir my-custom-rule
+```sh
+ mkdir my-custom-rule
 
-$ cd my-custom-rule
+ cd my-custom-rule
 
-$ yarn init -y
+ npm init -y
 ```
 
 Now we can start installing our dependencies.
 
-```bash
-$ yarn add remark-lint remark-cli
+```sh
+ npm install remark-lint remark-cli
 ```
 
-*   [remark-lint](https://github.com/remarkjs/remark-lint): a plugin to lint markdown built on [remark](https://github.com/remarkjs/remark): (a markdown processor).
-*   [remark-cli](https://github.com/remarkjs/remark/tree/main/packages/remark-cli): remark CLI.
+*   [`remark-lint`](https://github.com/remarkjs/remark-lint): Core lint plugin
+*   [`remark-cli`](https://github.com/remarkjs/remark/tree/main/packages/remark-cli): Command-line interface
 
-Because we will be working with [ASTs](https://en.wikipedia.org/wiki/Abstract_syntax_tree), we will also need some utilities:
+We will also need some utilities:
 
-```bash
-$ yarn unified-lint-rule unist-util-generated unist-util-visit
+```sh
+ npm install unified-lint-rule unist-util-generated unist-util-visit
 ```
 
 These will help us creating and managing our custom rules.
 
-[Back to Top](#table-of-contents)
+[Back to Top](#contents)
 
 ## Set up remark
 
-With our dependencies all installed, we can start creating a `.remarkrc.js`, which will contain all the plugins that will be consumed by the remark processor.
-For details about alternative or advanced configurations, please refer to [Configuring remark-lint](https://github.com/remarkjs/remark-lint#configuring-remark-lint).
+With everything installed, we can now create a `.remarkrc.js` that will contain the plugins we’ll use.
 
-```bash
-$ touch .remarkrc.js
+For more info on configuration, see [Configuring `remark-lint`](https://github.com/remarkjs/remark-lint#configuring-remark-lint).
+
+```sh
+ touch .remarkrc.js
 ```
 
 ```js
@@ -70,15 +71,15 @@ Then, in our `package.json`, let's add the following script, which will process 
 }
 ```
 
-Let's create a `doc.md`, the markdown file we want to lint,
+Let's create a `doc.md`, the markdown file we want to lint:
 
-```bash
-$ touch doc.md
+```sh
+ touch doc.md
 ```
 
-and copy/paste this content:
+...and copy/paste the following:
 
-```md
+```markdown
 ## Best pets! <3
 
 Some funny images of our favorite pets
@@ -90,44 +91,45 @@ Some funny images of our favorite pets
 
 At this point, we have a working `remark` configuration and a markdown file in the project.
 
-If we run `yarn run lint` we should expect to see in our terminal:
+If we run `npm run lint` we should expect to see in our terminal:
 
-```bash
-$ doc.md: no issues found
+```sh
+ doc.md: no issues found
 ```
 
 All good, the file has been processed, and because we haven't specified any plugins nor lint rule, no issues are found.
 
-[Back to Top](#table-of-contents)
+[Back to Top](#contents)
 
-## The no-invalid-gif rule
+## The `no-invalid-gif` rule
 
-Let's imagine we want to write a rule that checks whether a `.gif` file is used within an image.
+Let’s imagine we want to write a rule that checks whether a `.gif` file is used as an image.
 
 Given the content of our `doc.md` file declared above, we would expect an *error* or *warning* pointing to:
 
-```md
+```markdown
 ![a funny cat](funny-cat.gif)
 ```
 
-Because the file extension `.gif` in the image tag, violates our rule.
+Because the file extension `.gif` in the image tag violates our rule.
 
-[Back to Top](#table-of-contents)
+[Back to Top](#contents)
 
 ## Create the custom rule
 
 Let's create a new folder `rules` under the root directory, where we will place all of our custom rules, and create a new file in it named `no-gif-allowed.js`.
 
-```bash
-$ mkdir rules
-$ cd rules
-$ touch no-gif-allowed.js
-$ cd .. # return to project root
+```sh
+ mkdir rules
+ cd rules
+ touch no-gif-allowed.js
+ cd .. # return to project root
 ```
 
-*Remember*: the name of the folder and files, and where to place them within your project, is entirely up to you.
+*Note*: the name of folders and files, and where to place them within your project, is up to you.
 
-In `./rules/no-gif-allowed.js`, let's import the `unified-lint-rule`.
+In `./rules/no-gif-allowed.js`, let's import `unified-lint-rule`.
+
 We then export the result of calling `rule` by providing the *namespace and rule name* (`remark-lint:no-gif-allowed`) as the first argument, and our implementation of the rule (`noGifAllowed`) as the second argument.
 
 ```js
@@ -148,9 +150,9 @@ module.exports = rule("my-project-name:no-gif-allowed", noGifAllowed);
 module.exports = rule("my-npm-published-package:no-gif-allowed", noGifAllowed);
 ```
 
-This can help you when wanting to create a group of rules under the same *label* or *namespace*.
+This can help you when wanting to create a group of rules under the same *namespace*.
 
-[Back to Top](#table-of-contents)
+[Back to Top](#contents)
 
 ## Rule arguments
 
@@ -160,15 +162,15 @@ Your rule function will receive three arguments.
 function noGifAllowed(tree, file, options) {}
 ```
 
-*   `tree` (*required*): a [mdast](https://github.com/syntax-tree/mdast).
-*   `file` (*required*): a [virtual file format](https://github.com/vfile/vfile).
-*   `options` (*optional*): additional information passed to the rule by the remark plugins definition.
+*   `tree` (*required*): [mdast](https://github.com/syntax-tree/mdast)
+*   `file` (*required*): [virtual file](https://github.com/vfile/vfile)
+*   `options` (*optional*): additional information passed to the rule by users
 
-[Back to Top](#table-of-contents)
+[Back to Top](#contents)
 
 ## Rule implementation
 
-Because we will be inspecting a [mdast](https://github.com/syntax-tree/mdast), which is a markdown abstract syntax tree built upon [unist](https://github.com/syntax-tree/unist), we can take advantage of the many existing [unist utilities](https://github.com/syntax-tree/unist#utilities) to inspect our tree's nodes.
+Because we will be inspecting [mdast](https://github.com/syntax-tree/mdast), which is a markdown abstract syntax tree built upon [unist](https://github.com/syntax-tree/unist), we can take advantage of the many existing [unist utilities](https://github.com/syntax-tree/unist#utilities) to inspect our tree’s nodes.
 
 For this example, we will use [`unist-util-visit`](https://github.com/syntax-tree/unist-util-visit) to recursively inspect all the image nodes, and [`unist-util-generated`](https://github.com/syntax-tree/unist-util-generated) to ensure we are not inspecting nodes that we have generated ourselves and do not belong to the `doc.md`.
 
@@ -178,8 +180,8 @@ const visit = require("unist-visit-util");
 const generated = require("unist-util-generated");
 
 function isValidNode(node) {
-  // here we check whether the given node violates our rule
-  // implementation details are not relevant to the scope of this example.
+  // Here we check whether the given node violates our rule.
+  // Implementation details are not relevant to the scope of this example.
   // This is an overly simplified solution for demonstration purposes
   if (node.url && typeof node.url === "string") {
     return !node.url.endsWith(".gif");
@@ -189,12 +191,10 @@ function noGifAllowed(tree, file, options) {
   visit(tree, "image", visitor);
   function visitor(node) {
     if (!generated(node)) {
-      /**
-       * This is an extremely simplified example of how to structure
-       * the logic to check whether a node violates your rule.
-       * You have complete freedom over how to visit/inspect the tree,
-       * and on how to implement the validation logic for your node.
-       * */
+       // This is an extremely simplified example of how to structure
+       // the logic to check whether a node violates your rule.
+       // You have complete freedom over how to visit/inspect the tree,
+       //and on how to implement the validation logic for your node.
       const isValid = isValidNode(node);
       if (!isValid) {
         // remember to provide the node as second argument to the message,
@@ -210,13 +210,13 @@ function noGifAllowed(tree, file, options) {
 module.exports = rule("remark-lint:no-gif-allowed", noGifAllowed);
 ```
 
-[Back to Top](#table-of-contents)
+[Back to Top](#contents)
 
 ## Import the rule in your remark config
 
 Now that our custom rule is defined, and ready to be used, we need to add it to our `remark` configuration.
 
-All you have to do is to import your rule into the `remark` configuration plugins array:
+You can do that by importing your rule and adding it in `plugins` array:
 
 ```js
 // .remarkrc.js
@@ -227,16 +227,16 @@ module.exports = {
 };
 ```
 
-[Back to Top](#table-of-contents)
+[Back to Top](#contents)
 
 ## Apply the rule on the Markdown file
 
-If you run `yarn lint`, you should see the following message in the terminal:
+If you run `npm lint`, you should see the following message in the terminal:
 
-```bash
+```sh
  5:1-5:30  warning  Invalid image file extentions. Please do not use gifs  no-gif-allowed  remark-lint
 ```
 
 **Congratulations! The rule works!**
 
-[Back to Top](#table-of-contents)
+[Back to Top](#contents)

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -51,7 +51,7 @@ With everything installed, we can now create a `.remarkrc.js` that will contain 
 For more info on configuration, see [Configuring `remark-lint`](https://github.com/remarkjs/remark-lint#configuring-remark-lint).
 
 ```sh
- touch .remarkrc.js
+touch .remarkrc.js
 ```
 
 ```js

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -114,7 +114,7 @@ Because the file extension `.gif` in the image violates our rule.
 
 ## Create the custom rule
 
-Let's create a new folder `rules` under the root directory, where we will place all of our custom rules, and create a new file in it named `no-gif-allowed.js`.
+Let’s create a new folder `rules` under the root directory, where we will place all of our custom rules, and create a new file in it named `no-gif-allowed.js`.
 
 ```sh
  mkdir rules

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -61,7 +61,7 @@ module.exports = {
 }
 ```
 
-Then, in our `package.json`, let's add the following script, which will process all the markdown file within our project:
+Then, in our `package.json`, add the following script to process all the markdown files in our project:
 
 ```json
 "scripts": {

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -232,8 +232,8 @@ module.exports = {
 
 If you run `npm run lint`, you should see the following message in the terminal:
 
-```sh
- 5:1-5:30  warning  Invalid image file extentions. Please do not use gifs  no-gif-allowed  remark-lint
+```text
+5:1-5:30  warning  Invalid image file extentions. Please do not use gifs  no-gif-allowed  remark-lint
 ```
 
 **Congratulations! The rule works!**

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -197,7 +197,7 @@ function noGifAllowed(tree, file, options) {
        //and on how to implement the validation logic for your node.
       const isValid = isValidNode(node);
       if (!isValid) {
-        // remember to provide the node as second argument to the message,
+        // Remember to provide the node as second argument to the message,
         // in order to obtain the position and column where the violation occurred.
         file.message(
           `Invalid image file extentions. Please do not use gifs`,

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -132,11 +132,11 @@ We then export the result of calling `rule` by providing the *namespace and rule
 ```js
 // rules/no-gif-allowed.js
 
-var rule = require("unified-lint-rule");
+var rule = require('unified-lint-rule')
 function noGifAllowed(tree, file, options) {
-  // rule implementation
+  // Rule implementation
 }
-module.exports = rule("remark-lint:no-gif-allowed", noGifAllowed);
+module.exports = rule('remark-lint:no-gif-allowed', noGifAllowed)
 ```
 
 Let’s say you want all your custom rules to be defined as part of your project namespace.

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -95,7 +95,7 @@ If we run `npm run lint` we should expect to see in our terminal:
 doc.md: no issues found
 ```
 
-All good, the file has been processed, and because we haven't specified any plugins nor lint rule, no issues are found.
+All good, the file has been processed, and because we haven’t specified any plugins nor lint rules, no issues are found.
 
 [Back to Top](#contents)
 

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -17,7 +17,7 @@ This guide is part of [a step-by-step tutorial](https://dev.to/floroz/how-to-cre
 
 Create a new folder and enter it from your terminal.
 For this example I will be using Unix commands (macOS and Linux compatible).
-Now we can generate our `package.json`
+Then generate a `package.json`:
 
 ```sh
 mkdir my-custom-rule

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -19,11 +19,9 @@ Create a new folder and enter it from your terminal. For this example I will be 
 Now we can generate our `package.json`
 
 ```sh
- mkdir my-custom-rule
-
- cd my-custom-rule
-
- npm init -y
+mkdir my-custom-rule
+cd my-custom-rule
+npm init -y
 ```
 
 Now we can start installing our dependencies.

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -1,20 +1,18 @@
 # Create a custom `remark-lint` rule
 
-The following is a short guide on how to setup a JavaScript project and create a linting plugin for `remark` using `remark-lint`.
+This tutorial will help you setting up a JavaScript project, and creating your first linting plugin for `remark`.
 
 ## Table of Contents
+*   [Set up the project](#set-up-the-project)
+*   [Set up remark](#set-up-remark)
+*   [The no-invalid-gif rule:](#the-no-invalid-gif-rule)
+*   [Create the custom rule](#create-the-custom-rule)
+*   [Rule arguments](#rule-arguments)
+*   [Rule implementation](#rule-implementation)
+*   [Import the rule in your remark config](#import-the-rule-in-your-remark-config)
+*   [Apply the rule](#apply-the-rule)
 
-* [Set up the project](#1-set-up-the-project)
-* [Set up remark](#2-set-up-remark)
-* [The no-invalid-gif rule](#3-the-no-invalid-gif-rule)
-* [Create the custom rule](#4-create-the-custom-rule)
-* [Rule arguments](#5-rule-arguments)
-* [Rule implementation](#6-rule-implementation)
-* [Import the rule in your remark config](#7-import-the-rule-in-your-remark-config)
-* [Apply the rule](#8-apply-the-rule)
-
-
-### 1. Set up the project
+### Set up the project
 
 Let's set up the project and start adding our dependencies.
 
@@ -28,9 +26,9 @@ Now that we have a `package.json`, we can install our processor and lint plugin:
 yarn add remark remark-lint remark-cli
 ```
 
-- [remark](https://github.com/remarkjs/remark): a markdown processor.
-- [remark-lint](https://github.com/remarkjs/remark-lint): remark plugins to lint markdown.
-- [remark-cli](https://github.com/remarkjs/remark/tree/main/packages/remark-cli): CLI.
+*   [remark](https://github.com/remarkjs/remark): a markdown processor.
+*   [remark-lint](https://github.com/remarkjs/remark-lint): remark plugins to lint markdown.
+*   [remark-cli](https://github.com/remarkjs/remark/tree/main/packages/remark-cli): CLI.
 
 Because we will be working with [ASTs](https://en.wikipedia.org/wiki/Abstract_syntax_tree), we will also need some utilities:
 
@@ -40,7 +38,7 @@ yarn unified-lint-rule unist-util-generated unist-util-visit
 
 These will help us creating and managing our custom rules.
 
-### 2. Set up remark
+### Set up remark
 
 With our dependencies all installed, we can start creating a `.remarkrc.js`, which will contain all the plugins that will be consumed by the remark processor.
 For details about alternative or advanced configurations, please refer to [Configuring remark-lint](https://github.com/remarkjs/remark-lint#configuring-remark-lint).
@@ -83,7 +81,7 @@ doc.md: no issues found
 
 All good, the file has been processed, and because we haven't specified any plugins nor lint rule, no issues are found.
 
-### 3. The no-invalid-gif rule:
+### The no-invalid-gif rule
 
 Let's imagine we want to write a rule that checks whether a `.gif` file is used within an image.
 
@@ -99,16 +97,16 @@ Some funny images of our favourite pets
 ![a lovely dog](lovely-dog.png)
 ```
 
-We would expect an _error_ or _warning_ pointing to `funny-cat.gif`, because the file extension `.gif` violates our rule.
+We would expect an *error* or *warning* pointing to `funny-cat.gif`, because the file extension `.gif` violates our rule.
 
-### 4. Create the custom rule
+### Create the custom rule
 
 Let's create a new folder `rules` under the root directory, where we will place all of our custom rules, and create a new file in it named `no-gif-allowed.js`.
 
-_Remember_: the name of the folder and files, and where to place them within your project, is entirely up to you.
+*Remember*: the name of the folder and files, and where to place them within your project, is entirely up to you.
 
 In `./rules/no-gif-allowed.js`, let's import the `unified-lint-rule`.
-We then export the result of calling `rule` by providing the _namespace and rule name_ (`remark-lint:no-gif-allowed`) as the first argument, and our implementation of the rule (`noGifAllowed`) as the second argument.
+We then export the result of calling `rule` by providing the *namespace and rule name* (`remark-lint:no-gif-allowed`) as the first argument, and our implementation of the rule (`noGifAllowed`) as the second argument.
 
 ```js
 // rules/no-gif-allowed.js
@@ -126,9 +124,9 @@ Let's say you want all your custom rules to be defined as part of your project n
 module.exports = rule("my-project:no-gif-allowed", noGifAllowed);
 ```
 
-This can help you when wanting to create a group of rules under the same _label_ or _namespace_.
+This can help you when wanting to create a group of rules under the same *label* or *namespace*.
 
-### 5. Rule arguments
+### Rule arguments
 
 Your rule function will receive three arguments.
 
@@ -136,11 +134,11 @@ Your rule function will receive three arguments.
 function noGifAllowed(tree, file, options) {}
 ```
 
-- `tree` (_required_): a [mdast](https://github.com/syntax-tree/mdast).
-- `file` (_required_): a [virtual file format](https://github.com/vfile/vfile).
-- `options` (_optional_): additional information passed to the rule by the remark plugins definition.
+*   `tree` (*required*): a [mdast](https://github.com/syntax-tree/mdast).
+*   `file` (*required*): a [virtual file format](https://github.com/vfile/vfile).
+*   `options` (*optional*): additional information passed to the rule by the remark plugins definition.
 
-### 6. Rule implementation
+### Rule implementation
 
 Because we will be inspecting a [mdast](https://github.com/syntax-tree/mdast), which is a markdown abstract syntax tree built upon [unist](https://github.com/syntax-tree/unist), we can take advantage of the many existing [unist utilities](https://github.com/syntax-tree/unist#utilities) to inspect our tree's nodes.
 
@@ -184,7 +182,7 @@ function noGifAllowed(tree, file, options) {
 module.exports = rule("remark-lint:no-gif-allowed", noGifAllowed);
 ```
 
-### 7. Import the rule in your remark config
+### Import the rule in your remark config
 
 Now that our custom rule is defined, and ready to be used, we need to add it to our `remark` configuration.
 
@@ -199,7 +197,7 @@ module.exports = {
 };
 ```
 
-### 8. Apply the rule
+### Apply the rule
 
 If you run `yarn lint`, you should see the following message in the terminal:
 
@@ -207,6 +205,6 @@ If you run `yarn lint`, you should see the following message in the terminal:
  5:1-5:30  warning  Invalid image file extentions. Please do not use gifs  no-gif-allowed  remark-lint
 ```
 
-#### Congratulations!
+**Congratulations!**
 
 The violation has been correctly found and reported.

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -173,9 +173,9 @@ Because we will be inspecting [mdast](https://github.com/syntax-tree/mdast), whi
 For this example, we will use [`unist-util-visit`](https://github.com/syntax-tree/unist-util-visit) to recursively inspect all the image nodes, and [`unist-util-generated`](https://github.com/syntax-tree/unist-util-generated) to ensure we are not inspecting nodes that we have generated ourselves and do not belong to the `doc.md`.
 
 ```js
-const rule = require("unified-lint-rule");
-const visit = require("unist-visit-util");
-const generated = require("unist-util-generated");
+const rule = require('unified-lint-rule')
+const visit = require('unist-visit-util')
+const generated = require('unist-util-generated')
 
 function isValidNode(node) {
   // Here we check whether the given node violates our rule.

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -230,7 +230,7 @@ module.exports = {
 
 ## Apply the rule on the Markdown file
 
-If you run `npm lint`, you should see the following message in the terminal:
+If you run `npm run lint`, you should see the following message in the terminal:
 
 ```sh
  5:1-5:30  warning  Invalid image file extentions. Please do not use gifs  no-gif-allowed  remark-lint

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -6,7 +6,7 @@ This guide is part of [a step-by-step tutorial](https://dev.to/floroz/how-to-cre
 
 *   [Set up the project](#set-up-the-project)
 *   [Set up remark](#set-up-remark)
-*   [The no-invalid-gif rule](#the-no-invalid-gif-rule)
+*   [The `no-invalid-gif` rule](#the-no-invalid-gif-rule)
 *   [Create the custom rule](#create-the-custom-rule)
 *   [Rule arguments](#rule-arguments)
 *   [Rule implementation](#rule-implementation)

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -92,7 +92,7 @@ At this point, we have a working `remark` configuration and a markdown file in t
 If we run `npm run lint` we should expect to see in our terminal:
 
 ```sh
- doc.md: no issues found
+doc.md: no issues found
 ```
 
 All good, the file has been processed, and because we haven't specified any plugins nor lint rule, no issues are found.

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -1,0 +1,130 @@
+# Create a custom `remark-lint` rule
+
+The following is a short guide on how to extend your `remark-lint` configuration to include custom rules.
+
+## Example of a new rule `remark-lint:no-gif-allowed`
+
+Let's imagine we want to write a rule that checks whether a `.gif` file is used within an image.
+
+We have a `blog-post.md` file.
+
+```md
+## Best pets! <3
+
+Some funny images of our favourite pets
+
+![a funny cat](funny-cat.gif)
+
+![a lovely dog](lovely-dog.png)
+```
+
+We expect an *error* or *warning* highlighting `funny-cat.gif`, because the file extension `.gif` violates our rule.
+
+### 1. Create a new file
+
+First, let's create a new folder `rules` under the root directory, where we will place all of our custom rules, and create a new file `no-gif-allowed.js`.
+
+*Remember*: the name of the folder and files, and where to place them within your project, is entirely up to you.
+
+In `./rules/no-gif-allowed.js`, let's import the `unified-lint-rule`.
+We then export the result of calling `rule` by providing the *namespace and rule name* (`remark-lint:no-gif-allowed`) as first argument, the *rule itself* (`noGifAllowed`) as second argument.
+
+```js
+var rule = require('unified-lint-rule')
+
+function noGifAllowed(tree, file, options) {
+  // rule implementation
+}
+
+module.exports = rule('remark-lint:no-gif-allowed', noGifAllowed)
+```
+
+Let's say you want all your custom rules to be defined as part of your project namespace. If your project was named `my-project` than you can export your rule as:
+
+```js
+module.exports = rule('my-project:no-gif-allowed', noGifAllowed)
+```
+
+### 2. Rule arguments
+
+Your rule function will receive three arguments.
+
+```js
+function noGifAllowed(tree, file, options) {}
+```
+
+*   `tree` (*required*): a [mdast](https://github.com/syntax-tree/mdast).
+*   `file` (*required*): a [virtual file format](https://github.com/vfile/vfile).
+*   `options` (*optional*): additional information passed to the rule by the remark plugins definition.
+
+### 3. Define the rule
+
+Because we will be inspecting a [mdast](https://github.com/syntax-tree/mdast), which is a markdown abstract syntax tree built upon [unist](https://github.com/syntax-tree/unist), we can take advantage of the many existing [unist utilities](https://github.com/syntax-tree/unist#utilities) to inspect our tree's nodes.
+
+For this example, we will use [`unist-util-visit`](https://github.com/syntax-tree/unist-util-visit) to recursively inspect all the image nodes, and [`unist-util-generated`](https://github.com/syntax-tree/unist-util-generated) to ensure we are not inspecting nodes that we have generated ourselves and do not belog to the `blog-post.md`.
+
+```js
+var rule = require('unified-lint-rule')
+var visit = require('unist-visit-util')
+var generated = require('unist-util-generated')
+
+
+function isValidNode(node) {
+  // here we check whether the given node violates our rule
+  // implementation details are not relevant to the scope of this example.
+}
+
+function noGifAllowed(tree, file, options) {
+
+  visit(tree, 'image', visitor);
+
+  function visitor(node) {
+    if (!generated(node)) {
+
+      /**
+       * This is an extremely simplified example on how to structure
+       * the logic to check whether a node violates your rule.
+       * You have complete freedom on how to visit/inspect the tree,
+       * and how to implement the validation logic for your node.
+       * */
+      var isValid = isValidNode(node)
+
+      if (!isValid) {
+        // remember to pass the node itself alongside message, to obtain the position and column where the violation occurred.
+        file.message(`Invalid image file extentions. Please do not use gifs`, node)
+      }
+    }
+  }
+
+}
+
+module.exports = rule('remark-lint:no-gif-allowed', noGifAllowed)
+
+```
+
+### 4. Import the rule in your remark config
+
+Now that our custom rule is defined, and ready to be used, we need to add it to our `remark` configuration.
+For details about the configuration, please refer to our [Configuring remark-lint](https://github.com/remarkjs/remark-lint#configuring-remark-lint).
+
+All you have to do, is to import your rule into the `remark` configuration plugins array:
+
+**Example of a `.remarkrc.js` config file**
+
+```js
+// .remarkrc.js
+
+var noGifAllowed = require('./rules/no-gif-allowed.js')
+
+module.exports = {
+  plugins: [
+    noGifAllowed,
+  ]
+}
+```
+
+Now running `remark-lint` through the CLI, or through a ESLint integration, should yeld:
+
+```bash
+ 5:10  error  'Invalid image file extentions. Please do not use gifs'   no-invalid-gif  remark-lint
+```

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -108,7 +108,7 @@ Given the content of our `doc.md` file declared above, we would expect an *error
 ![a funny cat](funny-cat.gif)
 ```
 
-Because the file extension `.gif` in the image tag violates our rule.
+Because the file extension `.gif` in the image violates our rule.
 
 [Back to Top](#contents)
 

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -206,7 +206,7 @@ function noGifAllowed(tree, file, options) {
     }
   }
 }
-module.exports = rule("remark-lint:no-gif-allowed", noGifAllowed);
+module.exports = rule('remark-lint:no-gif-allowed', noGifAllowed)
 ```
 
 [Back to Top](#contents)

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -139,7 +139,8 @@ function noGifAllowed(tree, file, options) {
 module.exports = rule("remark-lint:no-gif-allowed", noGifAllowed);
 ```
 
-Let's say you want all your custom rules to be defined as part of your project namespace. If your project was named `my-project`, then you can export your rule as:
+Let’s say you want all your custom rules to be defined as part of your project namespace.
+If your project was named `my-project`, then you can export your rule as:
 
 ```js
 module.exports = rule("my-project-name:no-gif-allowed", noGifAllowed);

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -69,7 +69,7 @@ Then, in our `package.json`, let's add the following script, which will process 
 }
 ```
 
-Let's create a `doc.md`, the markdown file we want to lint:
+Let’s create a `doc.md`, the markdown file we want to lint:
 
 ```sh
  touch doc.md

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -117,10 +117,10 @@ Because the file extension `.gif` in the image violates our rule.
 Let’s create a new folder `rules` under the root directory, where we will place all of our custom rules, and create a new file in it named `no-gif-allowed.js`.
 
 ```sh
- mkdir rules
- cd rules
- touch no-gif-allowed.js
- cd .. # return to project root
+mkdir rules
+cd rules
+touch no-gif-allowed.js
+cd .. # return to project root
 ```
 
 *Note*: the name of folders and files, and where to place them within your project, is up to you.

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -2,17 +2,18 @@
 
 This tutorial will help you creating your first linting plugin for `remark`.
 
-### Table of Contents
+## Table of Contents
 
-<!-- *   [Set up the project](#set-up-the-project) -->
-
+*   [Set up the project](#set-up-the-project)
 *   [Set up remark](#set-up-remark)
 *   [The no-invalid-gif rule](#the-no-invalid-gif-rule)
 *   [Create the custom rule](#create-the-custom-rule)
 *   [Rule arguments](#rule-arguments)
 *   [Rule implementation](#rule-implementation)
 *   [Import the rule in your remark config](#import-the-rule-in-your-remark-config)
-*   [Apply the rule](#apply-the-rule)
+*   [Apply the rule on the Markdown file](#apply-the-rule-on-the-markdown-file)
+
+Fork this [repository](https://github.com/floroz/blog-posts/tree/main/how-to-create-custom-lint-rule-markdown-mdx) with the complete tutorial, if you don't want to start from scratch.
 
 \## Set up the project
 
@@ -20,17 +21,17 @@ Create a new folder and navigate inside it from your Terminal. For this example 
 Now we can generate our `package.json`
 
 ```bash
-mkdir my-custom-rule
+$ mkdir my-custom-rule
 
-cd my-custom-rule
+$ cd my-custom-rule
 
-yarn init -y
+$ yarn init -y
 ```
 
 Now we can start installing our dependencies.
 
 ```bash
-yarn add remark-lint remark-cli
+$ yarn add remark-lint remark-cli
 ```
 
 *   [remark-lint](https://github.com/remarkjs/remark-lint): a plugin to lint markdown built on [remark](https://github.com/remarkjs/remark): (a markdown processor).
@@ -39,15 +40,21 @@ yarn add remark-lint remark-cli
 Because we will be working with [ASTs](https://en.wikipedia.org/wiki/Abstract_syntax_tree), we will also need some utilities:
 
 ```bash
-yarn unified-lint-rule unist-util-generated unist-util-visit
+$ yarn unified-lint-rule unist-util-generated unist-util-visit
 ```
 
 These will help us creating and managing our custom rules.
+
+[Back to Top](#table-of-contents)
 
 ## Set up remark
 
 With our dependencies all installed, we can start creating a `.remarkrc.js`, which will contain all the plugins that will be consumed by the remark processor.
 For details about alternative or advanced configurations, please refer to [Configuring remark-lint](https://github.com/remarkjs/remark-lint#configuring-remark-lint).
+
+```bash
+$ touch .remarkrc.js
+```
 
 ```js
 // .remarkrc.js
@@ -65,7 +72,13 @@ Then, in our `package.json`, let's add the following script, which will process 
 }
 ```
 
-Let's create a `doc.md`, the markdown file we want to lint:
+Let's create a `doc.md`, the markdown file we want to lint,
+
+```bash
+$ touch doc.md
+```
+
+and copy/paste this content:
 
 ```md
 ## Best pets! <3
@@ -82,32 +95,36 @@ At this point, we have a working `remark` configuration and a markdown file in t
 If we run `yarn run lint` we should expect to see in our terminal:
 
 ```bash
-doc.md: no issues found
+$ doc.md: no issues found
 ```
 
 All good, the file has been processed, and because we haven't specified any plugins nor lint rule, no issues are found.
+
+[Back to Top](#table-of-contents)
 
 ## The no-invalid-gif rule
 
 Let's imagine we want to write a rule that checks whether a `.gif` file is used within an image.
 
-Given the content of our `doc.md` file:
+Given the content of our `doc.md` file declared above, we would expect an *error* or *warning* pointing to:
 
 ```md
-## Best pets! <3
-
-Some funny images of our favourite pets
-
 ![a funny cat](funny-cat.gif)
-
-![a lovely dog](lovely-dog.png)
 ```
 
-We would expect an *error* or *warning* pointing to `funny-cat.gif`, because the file extension `.gif` violates our rule.
+Because the file extension `.gif` in the image tag, violates our rule.
+
+[Back to Top](#table-of-contents)
 
 ## Create the custom rule
 
 Let's create a new folder `rules` under the root directory, where we will place all of our custom rules, and create a new file in it named `no-gif-allowed.js`.
+
+```bash
+$ mkdir rules
+$ cd rules
+$ touch no-gif-allowed.js
+```
 
 *Remember*: the name of the folder and files, and where to place them within your project, is entirely up to you.
 
@@ -127,10 +144,14 @@ module.exports = rule("remark-lint:no-gif-allowed", noGifAllowed);
 Let's say you want all your custom rules to be defined as part of your project namespace. If your project was named `my-project`, then you can export your rule as:
 
 ```js
-module.exports = rule("my-project:no-gif-allowed", noGifAllowed);
+module.exports = rule("my-project-name:no-gif-allowed", noGifAllowed);
+// or
+module.exports = rule("my-npm-published-package:no-gif-allowed", noGifAllowed);
 ```
 
 This can help you when wanting to create a group of rules under the same *label* or *namespace*.
+
+[Back to Top](#table-of-contents)
 
 ## Rule arguments
 
@@ -144,11 +165,13 @@ function noGifAllowed(tree, file, options) {}
 *   `file` (*required*): a [virtual file format](https://github.com/vfile/vfile).
 *   `options` (*optional*): additional information passed to the rule by the remark plugins definition.
 
+[Back to Top](#table-of-contents)
+
 ## Rule implementation
 
 Because we will be inspecting a [mdast](https://github.com/syntax-tree/mdast), which is a markdown abstract syntax tree built upon [unist](https://github.com/syntax-tree/unist), we can take advantage of the many existing [unist utilities](https://github.com/syntax-tree/unist#utilities) to inspect our tree's nodes.
 
-For this example, we will use [`unist-util-visit`](https://github.com/syntax-tree/unist-util-visit) to recursively inspect all the image nodes, and [`unist-util-generated`](https://github.com/syntax-tree/unist-util-generated) to ensure we are not inspecting nodes that we have generated ourselves and do not belong to the `blog-post.md`.
+For this example, we will use [`unist-util-visit`](https://github.com/syntax-tree/unist-util-visit) to recursively inspect all the image nodes, and [`unist-util-generated`](https://github.com/syntax-tree/unist-util-generated) to ensure we are not inspecting nodes that we have generated ourselves and do not belong to the `doc.md`.
 
 ```js
 const rule = require("unified-lint-rule");
@@ -188,6 +211,8 @@ function noGifAllowed(tree, file, options) {
 module.exports = rule("remark-lint:no-gif-allowed", noGifAllowed);
 ```
 
+[Back to Top](#table-of-contents)
+
 ## Import the rule in your remark config
 
 Now that our custom rule is defined, and ready to be used, we need to add it to our `remark` configuration.
@@ -203,7 +228,9 @@ module.exports = {
 };
 ```
 
-## Apply the rule
+[Back to Top](#table-of-contents)
+
+## Apply the rule on the Markdown file
 
 If you run `yarn lint`, you should see the following message in the terminal:
 
@@ -212,3 +239,5 @@ If you run `yarn lint`, you should see the following message in the terminal:
 ```
 
 **Congratulations! The rule works!**
+
+[Back to Top](#table-of-contents)

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -102,7 +102,6 @@ All good, the file has been processed, and because we haven’t specified any pl
 ## The `no-invalid-gif` rule
 
 Let’s imagine we want to write a rule that checks whether a `.gif` file is used as an image.
-
 Given the content of our `doc.md` file declared above, we would expect an *error* or *warning* pointing to:
 
 ```markdown

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -1,12 +1,13 @@
 # Create a custom `remark-lint` rule
 
-This tutorial will help you setting up a JavaScript project, and creating your first linting plugin for `remark`.
+This tutorial will help you creating your first linting plugin for `remark`.
 
 ### Table of Contents
 
-*   [Set up the project](#set-up-the-project)
+<!-- *   [Set up the project](#set-up-the-project) -->
+
 *   [Set up remark](#set-up-remark)
-*   [The no-invalid-gif rule:](#the-no-invalid-gif-rule)
+*   [The no-invalid-gif rule](#the-no-invalid-gif-rule)
 *   [Create the custom rule](#create-the-custom-rule)
 *   [Rule arguments](#rule-arguments)
 *   [Rule implementation](#rule-implementation)
@@ -15,21 +16,25 @@ This tutorial will help you setting up a JavaScript project, and creating your f
 
 \## Set up the project
 
-Let's set up the project and start adding our dependencies.
+Create a new folder and navigate inside it from your Terminal. For this example I will be using UNIX commands (macOS and Linux compatible).
+Now we can generate our `package.json`
 
 ```bash
+mkdir my-custom-rule
+
+cd my-custom-rule
+
 yarn init -y
 ```
 
-Now that we have a `package.json`, we can install our processor and lint plugin:
+Now we can start installing our dependencies.
 
 ```bash
-yarn add remark remark-lint remark-cli
+yarn add remark-lint remark-cli
 ```
 
-*   [remark](https://github.com/remarkjs/remark): a markdown processor.
-*   [remark-lint](https://github.com/remarkjs/remark-lint): remark plugins to lint markdown.
-*   [remark-cli](https://github.com/remarkjs/remark/tree/main/packages/remark-cli): CLI.
+*   [remark-lint](https://github.com/remarkjs/remark-lint): a plugin to lint markdown built on [remark](https://github.com/remarkjs/remark): (a markdown processor).
+*   [remark-cli](https://github.com/remarkjs/remark/tree/main/packages/remark-cli): remark CLI.
 
 Because we will be working with [ASTs](https://en.wikipedia.org/wiki/Abstract_syntax_tree), we will also need some utilities:
 
@@ -206,6 +211,4 @@ If you run `yarn lint`, you should see the following message in the terminal:
  5:1-5:30  warning  Invalid image file extentions. Please do not use gifs  no-gif-allowed  remark-lint
 ```
 
-**Congratulations!**
-
-The violation has been correctly found and reported.
+**Congratulations! The rule works!**

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -186,7 +186,7 @@ function isValidNode(node) {
   }
 }
 function noGifAllowed(tree, file, options) {
-  visit(tree, "image", visitor);
+  visit(tree, 'image', visitor)
   function visitor(node) {
     if (!generated(node)) {
        // This is an extremely simplified example of how to structure

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -1,12 +1,82 @@
 # Create a custom `remark-lint` rule
 
-The following is a short guide on how to extend your `remark-lint` configuration to include custom rules.
+The following is a short guide on how to setup a JavaScript project and create a linting plugin for `remark` using `remark-lint`.
 
-## Example of a new rule `remark-lint:no-gif-allowed`
+
+### 1. Set up the project
+
+Let's set up the project and start adding our dependencies.
+
+```bash
+yarn init -y
+```
+
+Now that we have a `package.json`, we can install our processor and lint plugin:
+
+```bash
+yarn add remark remark-lint remark-cli
+```
+
+- [remark](https://github.com/remarkjs/remark): a markdown processor.
+- [remark-lint](https://github.com/remarkjs/remark-lint): remark plugins to lint markdown.
+- [remark-cli](https://github.com/remarkjs/remark/tree/main/packages/remark-cli): CLI.
+
+Because we will be working with [ASTs](https://en.wikipedia.org/wiki/Abstract_syntax_tree), we will also need some utilities:
+
+```bash
+yarn unified-lint-rule unist-util-generated unist-util-visit
+```
+
+These will help us creating and managing our custom rules.
+
+### 2. Set up remark
+
+With our dependencies all installed, we can start creating a `.remarkrc.js`, which will contain all the plugins that will be consumed by the remark processor.
+For details about alternative or advanced configurations, please refer to [Configuring remark-lint](https://github.com/remarkjs/remark-lint#configuring-remark-lint).
+
+```js
+// .remarkrc.js
+
+module.exports = {
+  plugins: [],
+};
+```
+
+Then, in our `package.json`, let's add the following script, which will process all the markdown file within our project:
+
+```json
+"scripts": {
+  "lint": "remark ."
+}
+```
+
+Let's create a `doc.md`, the markdown file we want to lint:
+
+```md
+## Best pets! <3
+
+Some funny images of our favorite pets
+
+![a funny cat](funny-cat.gif)
+
+![a lovely dog](lovely-dog.png)
+```
+
+At this point, we have a working `remark` configuration and a markdown file in the project.
+
+If we run `yarn run lint` we should expect to see in our terminal:
+
+```bash
+doc.md: no issues found
+```
+
+All good, the file has been processed, and because we haven't specified any plugins nor lint rule, no issues are found.
+
+### 3. The `no-invalid-gif` rule:
 
 Let's imagine we want to write a rule that checks whether a `.gif` file is used within an image.
 
-We have a `blog-post.md` file.
+Given the content of our `doc.md` file:
 
 ```md
 ## Best pets! <3
@@ -18,34 +88,36 @@ Some funny images of our favourite pets
 ![a lovely dog](lovely-dog.png)
 ```
 
-We expect an *error* or *warning* highlighting `funny-cat.gif`, because the file extension `.gif` violates our rule.
+We would expect an _error_ or _warning_ pointing to `funny-cat.gif`, because the file extension `.gif` violates our rule.
 
-### 1. Create a new file
+### 4. Create the custom rule
 
-First, let's create a new folder `rules` under the root directory, where we will place all of our custom rules, and create a new file `no-gif-allowed.js`.
+Let's create a new folder `rules` under the root directory, where we will place all of our custom rules, and create a new file in it named `no-gif-allowed.js`.
 
-*Remember*: the name of the folder and files, and where to place them within your project, is entirely up to you.
+_Remember_: the name of the folder and files, and where to place them within your project, is entirely up to you.
 
 In `./rules/no-gif-allowed.js`, let's import the `unified-lint-rule`.
-We then export the result of calling `rule` by providing the *namespace and rule name* (`remark-lint:no-gif-allowed`) as first argument, the *rule itself* (`noGifAllowed`) as second argument.
+We then export the result of calling `rule` by providing the _namespace and rule name_ (`remark-lint:no-gif-allowed`) as the first argument, and our implementation of the rule (`noGifAllowed`) as the second argument.
 
 ```js
-var rule = require('unified-lint-rule')
+// rules/no-gif-allowed.js
 
+var rule = require("unified-lint-rule");
 function noGifAllowed(tree, file, options) {
   // rule implementation
 }
-
-module.exports = rule('remark-lint:no-gif-allowed', noGifAllowed)
+module.exports = rule("remark-lint:no-gif-allowed", noGifAllowed);
 ```
 
-Let's say you want all your custom rules to be defined as part of your project namespace. If your project was named `my-project` than you can export your rule as:
+Let's say you want all your custom rules to be defined as part of your project namespace. If your project was named `my-project`, then you can export your rule as:
 
 ```js
-module.exports = rule('my-project:no-gif-allowed', noGifAllowed)
+module.exports = rule("my-project:no-gif-allowed", noGifAllowed);
 ```
 
-### 2. Rule arguments
+This can help you when wanting to create a group of rules under the same _label_ or _namespace_.
+
+### 5. Rule arguments
 
 Your rule function will receive three arguments.
 
@@ -53,78 +125,77 @@ Your rule function will receive three arguments.
 function noGifAllowed(tree, file, options) {}
 ```
 
-*   `tree` (*required*): a [mdast](https://github.com/syntax-tree/mdast).
-*   `file` (*required*): a [virtual file format](https://github.com/vfile/vfile).
-*   `options` (*optional*): additional information passed to the rule by the remark plugins definition.
+- `tree` (_required_): a [mdast](https://github.com/syntax-tree/mdast).
+- `file` (_required_): a [virtual file format](https://github.com/vfile/vfile).
+- `options` (_optional_): additional information passed to the rule by the remark plugins definition.
 
-### 3. Define the rule
+### 6. Rule implementation
 
 Because we will be inspecting a [mdast](https://github.com/syntax-tree/mdast), which is a markdown abstract syntax tree built upon [unist](https://github.com/syntax-tree/unist), we can take advantage of the many existing [unist utilities](https://github.com/syntax-tree/unist#utilities) to inspect our tree's nodes.
 
-For this example, we will use [`unist-util-visit`](https://github.com/syntax-tree/unist-util-visit) to recursively inspect all the image nodes, and [`unist-util-generated`](https://github.com/syntax-tree/unist-util-generated) to ensure we are not inspecting nodes that we have generated ourselves and do not belog to the `blog-post.md`.
+For this example, we will use [`unist-util-visit`](https://github.com/syntax-tree/unist-util-visit) to recursively inspect all the image nodes, and [`unist-util-generated`](https://github.com/syntax-tree/unist-util-generated) to ensure we are not inspecting nodes that we have generated ourselves and do not belong to the `blog-post.md`.
 
 ```js
-var rule = require('unified-lint-rule')
-var visit = require('unist-visit-util')
-var generated = require('unist-util-generated')
-
+const rule = require("unified-lint-rule");
+const visit = require("unist-visit-util");
+const generated = require("unist-util-generated");
 
 function isValidNode(node) {
   // here we check whether the given node violates our rule
   // implementation details are not relevant to the scope of this example.
+  // This is an overly simplified solution for demonstration purposes
+  if (node.url && typeof node.url === "string") {
+    return !node.url.endsWith(".gif");
+  }
 }
-
 function noGifAllowed(tree, file, options) {
-
-  visit(tree, 'image', visitor);
-
+  visit(tree, "image", visitor);
   function visitor(node) {
     if (!generated(node)) {
-
       /**
-       * This is an extremely simplified example on how to structure
+       * This is an extremely simplified example of how to structure
        * the logic to check whether a node violates your rule.
-       * You have complete freedom on how to visit/inspect the tree,
-       * and how to implement the validation logic for your node.
+       * You have complete freedom over how to visit/inspect the tree,
+       * and on how to implement the validation logic for your node.
        * */
-      var isValid = isValidNode(node)
-
+      const isValid = isValidNode(node);
       if (!isValid) {
-        // remember to pass the node itself alongside message, to obtain the position and column where the violation occurred.
-        file.message(`Invalid image file extentions. Please do not use gifs`, node)
+        // remember to provide the node as second argument to the message,
+        // in order to obtain the position and column where the violation occurred.
+        file.message(
+          `Invalid image file extentions. Please do not use gifs`,
+          node
+        );
       }
     }
   }
-
 }
-
-module.exports = rule('remark-lint:no-gif-allowed', noGifAllowed)
-
+module.exports = rule("remark-lint:no-gif-allowed", noGifAllowed);
 ```
 
-### 4. Import the rule in your remark config
+### 7. Import the rule in your remark config
 
 Now that our custom rule is defined, and ready to be used, we need to add it to our `remark` configuration.
-For details about the configuration, please refer to our [Configuring remark-lint](https://github.com/remarkjs/remark-lint#configuring-remark-lint).
 
-All you have to do, is to import your rule into the `remark` configuration plugins array:
-
-**Example of a `.remarkrc.js` config file**
+All you have to do is to import your rule into the `remark` configuration plugins array:
 
 ```js
 // .remarkrc.js
-
-var noGifAllowed = require('./rules/no-gif-allowed.js')
+const noGifAllowed = require("./rules/no-gif-allowed.js");
 
 module.exports = {
-  plugins: [
-    noGifAllowed,
-  ]
-}
+  plugins: [noGifAllowed],
+};
 ```
 
-Now running `remark-lint` through the CLI, or through a ESLint integration, should yeld:
+### 8. Run the linter
+
+If you run `yarn lint`, you should see the following message in the terminal:
 
 ```bash
- 5:10  error  'Invalid image file extentions. Please do not use gifs'   no-invalid-gif  remark-lint
+ 5:1-5:30  warning  Invalid image file extentions. Please do not use gifs  no-gif-allowed  remark-lint
 ```
+
+#### Congratulations!
+
+The violation has been correctly found and reported.

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -56,10 +56,9 @@ touch .remarkrc.js
 
 ```js
 // .remarkrc.js
-
 module.exports = {
-  plugins: [],
-};
+  plugins: []
+}
 ```
 
 Then, in our `package.json`, let's add the following script, which will process all the markdown file within our project:

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -219,11 +219,11 @@ You can do that by importing your rule and adding it in `plugins` array:
 
 ```js
 // .remarkrc.js
-const noGifAllowed = require("./rules/no-gif-allowed.js");
+const noGifAllowed = require('./rules/no-gif-allowed.js')
 
 module.exports = {
-  plugins: [noGifAllowed],
-};
+  plugins: [noGifAllowed]
+}
 ```
 
 [Back to Top](#contents)

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -25,7 +25,7 @@ cd my-custom-rule
 npm init -y
 ```
 
-Now we can start installing our dependencies.
+Now we can start installing our dependencies:
 
 ```sh
  npm install remark-lint remark-cli

--- a/doc/create-a-custom-rule.md
+++ b/doc/create-a-custom-rule.md
@@ -75,7 +75,7 @@ Let’s create a `doc.md`, the markdown file we want to lint:
 touch doc.md
 ```
 
-...and copy/paste the following:
+…and copy/paste the following:
 
 ```markdown
 ## Best pets! <3

--- a/readme.md
+++ b/readme.md
@@ -407,7 +407,7 @@ This list is ordered based on the name without prefix, so excluding
 
 ## Create a custom rule
 
-Follow this [step by step guide](https://github.com/remarkjs/remark-lint/blob/main/doc/create-a-custom-rule.md) on how to create your own custom rule for `remark-lint`.
+Follow this comprehensive [tutorial](https://github.com/remarkjs/remark-lint/blob/main/doc/create-a-custom-rule.md) on how to create your own custom rule for `remark`.
 
 ## Security
 

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@ powered by [plugins][remark-plugins] (such as these).
 *   [Rules](#rules)
 *   [List of presets](#list-of-presets)
 *   [List of external rules](#list-of-external-rules)
+*   [Create a custom rule](#create-a-custom-rule)
 *   [Security](#security)
 *   [Related](#related)
 *   [Contribute](#contribute)
@@ -403,6 +404,10 @@ This list is ordered based on the name without prefix, so excluding
     — Wrapper for `write-good`
 *   [`remark-lint-double-link`](https://github.com/Scrum/remark-lint-double-link)
     — Ensure the same URL is not linked multiple times.
+
+## Create a custom rule
+
+Follow this [step by step guide](https://github.com/remarkjs/remark-lint/blob/main/doc/create-a-custom-rule.md) on how to create your own custom rule for `remark-lint`.
 
 ## Security
 


### PR DESCRIPTION
This PR adds a a step by step guide on how to create and add a custom rule to `remark-lint`.

The newly created guide is also added as a new section in the `readme.md`.

- Closes https://github.com/remarkjs/remark-lint/issues/261