### PR TITLE
Add `repository.directory` field to `package.json`s

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "private": true,
   "license": "MIT",
-  "repository": "https://github.com/remarkjs/remark-lint",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "author": "Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)",
   "contributors": [

--- a/packages/remark-lint-blockquote-indentation/package.json
+++ b/packages/remark-lint-blockquote-indentation/package.json
@@ -12,7 +12,11 @@
     "indentation",
     "indent"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-blockquote-indentation",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-blockquote-indentation"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-checkbox-character-style/package.json
+++ b/packages/remark-lint-checkbox-character-style/package.json
@@ -13,7 +13,11 @@
     "task",
     "list"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-checkbox-character-style",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-checkbox-character-style"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-checkbox-content-indent/package.json
+++ b/packages/remark-lint-checkbox-content-indent/package.json
@@ -13,7 +13,11 @@
     "task",
     "list"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-checkbox-content-indent",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-checkbox-content-indent"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-code-block-style/package.json
+++ b/packages/remark-lint-code-block-style/package.json
@@ -11,7 +11,11 @@
     "code",
     "block"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-code-block-style",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-code-block-style"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-definition-case/package.json
+++ b/packages/remark-lint-definition-case/package.json
@@ -11,7 +11,11 @@
     "definition",
     "case"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-definition-case",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-definition-case"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-definition-spacing/package.json
+++ b/packages/remark-lint-definition-spacing/package.json
@@ -11,7 +11,11 @@
     "definition",
     "spacing"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-definition-spacing",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-definition-spacing"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-emphasis-marker/package.json
+++ b/packages/remark-lint-emphasis-marker/package.json
@@ -11,7 +11,11 @@
     "emphasis",
     "marker"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-emphasis-marker",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-emphasis-marker"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-fenced-code-flag/package.json
+++ b/packages/remark-lint-fenced-code-flag/package.json
@@ -13,7 +13,11 @@
     "flag",
     "infostring"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-fenced-code-flag",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-fenced-code-flag"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-fenced-code-marker/package.json
+++ b/packages/remark-lint-fenced-code-marker/package.json
@@ -12,7 +12,11 @@
     "code",
     "marker"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-fenced-code-marker",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-fenced-code-marker"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-file-extension/package.json
+++ b/packages/remark-lint-file-extension/package.json
@@ -12,7 +12,11 @@
     "extension",
     "extname"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-file-extension",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-file-extension"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-final-definition/package.json
+++ b/packages/remark-lint-final-definition/package.json
@@ -12,7 +12,11 @@
     "position",
     "final"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-final-definition",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-final-definition"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-final-newline/package.json
+++ b/packages/remark-lint-final-newline/package.json
@@ -12,7 +12,11 @@
     "newline",
     "unix"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-final-newline",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-final-newline"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-first-heading-level/package.json
+++ b/packages/remark-lint-first-heading-level/package.json
@@ -13,7 +13,11 @@
     "level",
     "depth"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-first-heading-level",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-first-heading-level"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-hard-break-spaces/package.json
+++ b/packages/remark-lint-hard-break-spaces/package.json
@@ -13,7 +13,11 @@
     "spaces",
     "size"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-hard-break-spaces",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-hard-break-spaces"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-heading-increment/package.json
+++ b/packages/remark-lint-heading-increment/package.json
@@ -12,7 +12,11 @@
     "increment",
     "increase"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-heading-increment",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-heading-increment"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-heading-style/package.json
+++ b/packages/remark-lint-heading-style/package.json
@@ -13,7 +13,11 @@
     "atx",
     "setext"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-heading-style",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-heading-style"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-linebreak-style/package.json
+++ b/packages/remark-lint-linebreak-style/package.json
@@ -16,7 +16,11 @@
     "crlf",
     "lf"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-linebreak-style",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-linebreak-style"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-link-title-style/package.json
+++ b/packages/remark-lint-link-title-style/package.json
@@ -13,7 +13,11 @@
     "definition",
     "style"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-link-title-style",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-link-title-style"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-list-item-bullet-indent/package.json
+++ b/packages/remark-lint-list-item-bullet-indent/package.json
@@ -12,7 +12,11 @@
     "item",
     "indent"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-bullet-indent",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-list-item-bullet-indent"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-list-item-content-indent/package.json
+++ b/packages/remark-lint-list-item-content-indent/package.json
@@ -13,7 +13,11 @@
     "content",
     "indent"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-content-indent",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-list-item-content-indent"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-list-item-indent/package.json
+++ b/packages/remark-lint-list-item-indent/package.json
@@ -12,7 +12,11 @@
     "item",
     "indent"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-list-item-indent"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-list-item-spacing/package.json
+++ b/packages/remark-lint-list-item-spacing/package.json
@@ -13,7 +13,11 @@
     "loose",
     "tight"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-spacing",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-list-item-spacing"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-maximum-heading-length/package.json
+++ b/packages/remark-lint-maximum-heading-length/package.json
@@ -11,7 +11,11 @@
     "heading",
     "length"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-maximum-heading-length",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-maximum-heading-length"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-maximum-line-length/package.json
+++ b/packages/remark-lint-maximum-line-length/package.json
@@ -11,7 +11,11 @@
     "line",
     "length"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-maximum-line-length",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-maximum-line-length"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-auto-link-without-protocol/package.json
+++ b/packages/remark-lint-no-auto-link-without-protocol/package.json
@@ -12,7 +12,11 @@
     "link",
     "protocol"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-auto-link-without-protocol",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-auto-link-without-protocol"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-blockquote-without-marker/package.json
+++ b/packages/remark-lint-no-blockquote-without-marker/package.json
@@ -12,7 +12,11 @@
     "caret",
     "marker"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-blockquote-without-marker",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-blockquote-without-marker"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-consecutive-blank-lines/package.json
+++ b/packages/remark-lint-no-consecutive-blank-lines/package.json
@@ -11,7 +11,11 @@
     "blank",
     "lines"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-consecutive-blank-lines",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-consecutive-blank-lines"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-duplicate-defined-urls/package.json
+++ b/packages/remark-lint-no-duplicate-defined-urls/package.json
@@ -12,7 +12,11 @@
     "definition",
     "url"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-duplicate-defined-urls",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-duplicate-defined-urls"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-duplicate-definitions/package.json
+++ b/packages/remark-lint-no-duplicate-definitions/package.json
@@ -11,7 +11,11 @@
     "duplicate",
     "definition"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-duplicate-definitions",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-duplicate-definitions"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-duplicate-headings-in-section/package.json
+++ b/packages/remark-lint-no-duplicate-headings-in-section/package.json
@@ -12,7 +12,11 @@
     "heading",
     "section"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-duplicate-headings-in-section",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-duplicate-headings-in-section"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-duplicate-headings/package.json
+++ b/packages/remark-lint-no-duplicate-headings/package.json
@@ -11,7 +11,11 @@
     "duplicate",
     "heading"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-duplicate-headings",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-duplicate-headings"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-emphasis-as-heading/package.json
+++ b/packages/remark-lint-no-emphasis-as-heading/package.json
@@ -11,7 +11,11 @@
     "emphasis",
     "heading"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-emphasis-as-heading",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-emphasis-as-heading"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-empty-url/package.json
+++ b/packages/remark-lint-no-empty-url/package.json
@@ -13,7 +13,11 @@
     "link",
     "image"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-empty-url",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-empty-url"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-file-name-articles/package.json
+++ b/packages/remark-lint-no-file-name-articles/package.json
@@ -13,7 +13,11 @@
     "basename",
     "article"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-file-name-articles",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-file-name-articles"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-file-name-consecutive-dashes/package.json
+++ b/packages/remark-lint-no-file-name-consecutive-dashes/package.json
@@ -14,7 +14,11 @@
     "dash",
     "hyphen"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-file-name-consecutive-dashes",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-file-name-consecutive-dashes"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-file-name-irregular-characters/package.json
+++ b/packages/remark-lint-no-file-name-irregular-characters/package.json
@@ -13,7 +13,11 @@
     "irregular",
     "character"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-file-name-irregular-characters",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-file-name-irregular-characters"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-file-name-mixed-case/package.json
+++ b/packages/remark-lint-no-file-name-mixed-case/package.json
@@ -12,7 +12,11 @@
     "name",
     "case"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-file-name-mixed-case",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-file-name-mixed-case"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-file-name-outer-dashes/package.json
+++ b/packages/remark-lint-no-file-name-outer-dashes/package.json
@@ -13,7 +13,11 @@
     "dash",
     "hyphen"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-file-name-outer-dashes",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-file-name-outer-dashes"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-heading-content-indent/package.json
+++ b/packages/remark-lint-no-heading-content-indent/package.json
@@ -12,7 +12,11 @@
     "content",
     "indent"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-heading-content-indent",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-heading-content-indent"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-heading-indent/package.json
+++ b/packages/remark-lint-no-heading-indent/package.json
@@ -11,7 +11,11 @@
     "heading",
     "indent"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-heading-indent",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-heading-indent"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-heading-like-paragraph/package.json
+++ b/packages/remark-lint-no-heading-like-paragraph/package.json
@@ -11,7 +11,11 @@
     "heading",
     "paragraph"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-heading-like-paragraph",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-heading-like-paragraph"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-heading-punctuation/package.json
+++ b/packages/remark-lint-no-heading-punctuation/package.json
@@ -11,7 +11,11 @@
     "heading",
     "character"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-heading-punctuation",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-heading-punctuation"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-html/package.json
+++ b/packages/remark-lint-no-html/package.json
@@ -10,7 +10,11 @@
     "remark-lint-rule",
     "html"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-html",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-html"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-inline-padding/package.json
+++ b/packages/remark-lint-no-inline-padding/package.json
@@ -11,7 +11,11 @@
     "inline",
     "padding"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-inline-padding",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-inline-padding"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-literal-urls/package.json
+++ b/packages/remark-lint-no-literal-urls/package.json
@@ -11,7 +11,11 @@
     "literal",
     "url"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-literal-urls",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-literal-urls"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-missing-blank-lines/package.json
+++ b/packages/remark-lint-no-missing-blank-lines/package.json
@@ -11,7 +11,11 @@
     "blank",
     "line"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-missing-blank-lines",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-missing-blank-lines"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-multiple-toplevel-headings/package.json
+++ b/packages/remark-lint-no-multiple-toplevel-headings/package.json
@@ -11,7 +11,11 @@
     "top-level",
     "heading"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-multiple-toplevel-headings",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-multiple-toplevel-headings"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-paragraph-content-indent/package.json
+++ b/packages/remark-lint-no-paragraph-content-indent/package.json
@@ -12,7 +12,11 @@
     "content",
     "indent"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-paragraph-content-indent",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-paragraph-content-indent"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-reference-like-url/package.json
+++ b/packages/remark-lint-no-reference-like-url/package.json
@@ -12,7 +12,11 @@
     "url",
     "definition"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-reference-like-url",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-reference-like-url"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-shell-dollars/package.json
+++ b/packages/remark-lint-no-shell-dollars/package.json
@@ -11,7 +11,11 @@
     "dollar",
     "shel"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-shell-dollars",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-shell-dollars"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-shortcut-reference-image/package.json
+++ b/packages/remark-lint-no-shortcut-reference-image/package.json
@@ -12,7 +12,11 @@
     "reference",
     "image"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-shortcut-reference-image",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-shortcut-reference-image"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-shortcut-reference-link/package.json
+++ b/packages/remark-lint-no-shortcut-reference-link/package.json
@@ -12,7 +12,11 @@
     "reference",
     "link"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-shortcut-reference-link",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-shortcut-reference-link"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-table-indentation/package.json
+++ b/packages/remark-lint-no-table-indentation/package.json
@@ -11,7 +11,11 @@
     "table",
     "indent"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-table-indentation",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-table-indentation"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-tabs/package.json
+++ b/packages/remark-lint-no-tabs/package.json
@@ -10,7 +10,11 @@
     "remark-lint-rule",
     "tab"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-tabs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-tabs"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-undefined-references/package.json
+++ b/packages/remark-lint-no-undefined-references/package.json
@@ -11,7 +11,11 @@
     "reference",
     "definition"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-undefined-references",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-undefined-references"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-unneeded-full-reference-image/package.json
+++ b/packages/remark-lint-no-unneeded-full-reference-image/package.json
@@ -13,7 +13,11 @@
     "reference",
     "image"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-unneeded-full-reference-image",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-unneeded-full-reference-image"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-unneeded-full-reference-link/package.json
+++ b/packages/remark-lint-no-unneeded-full-reference-link/package.json
@@ -13,7 +13,11 @@
     "reference",
     "link"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-unneeded-full-reference-link",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-unneeded-full-reference-link"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-no-unused-definitions/package.json
+++ b/packages/remark-lint-no-unused-definitions/package.json
@@ -10,7 +10,11 @@
     "remark-lint-rule",
     "definition"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-unused-definitions",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-no-unused-definitions"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-ordered-list-marker-style/package.json
+++ b/packages/remark-lint-ordered-list-marker-style/package.json
@@ -12,7 +12,11 @@
     "list",
     "marker"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-style",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-ordered-list-marker-style"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-ordered-list-marker-value/package.json
+++ b/packages/remark-lint-ordered-list-marker-value/package.json
@@ -12,7 +12,11 @@
     "list",
     "marker"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-value",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-ordered-list-marker-value"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-rule-style/package.json
+++ b/packages/remark-lint-rule-style/package.json
@@ -12,7 +12,11 @@
     "thematic",
     "break"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-rule-style",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-rule-style"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-strikethrough-marker/package.json
+++ b/packages/remark-lint-strikethrough-marker/package.json
@@ -11,7 +11,11 @@
     "strikethrough",
     "marker"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-strikethrough-marker",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-strikethrough-marker"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-strong-marker/package.json
+++ b/packages/remark-lint-strong-marker/package.json
@@ -12,7 +12,11 @@
     "marker",
     "importance"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-strong-marker",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-strong-marker"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-table-cell-padding/package.json
+++ b/packages/remark-lint-table-cell-padding/package.json
@@ -12,7 +12,11 @@
     "cell",
     "padding"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-table-cell-padding",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-table-cell-padding"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",
@@ -31,8 +35,8 @@
     "index.js"
   ],
   "dependencies": {
-    "@types/unist": "^2.0.0",
     "@types/mdast": "^3.0.0",
+    "@types/unist": "^2.0.0",
     "unified": "^10.0.0",
     "unified-lint-rule": "^2.0.0",
     "unist-util-position": "^4.0.0",

--- a/packages/remark-lint-table-pipe-alignment/package.json
+++ b/packages/remark-lint-table-pipe-alignment/package.json
@@ -13,7 +13,11 @@
     "pipe",
     "align"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-table-pipe-alignment",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-table-pipe-alignment"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-table-pipes/package.json
+++ b/packages/remark-lint-table-pipes/package.json
@@ -12,7 +12,11 @@
     "row",
     "pipe"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-table-pipes",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-table-pipes"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint-unordered-list-marker-style/package.json
+++ b/packages/remark-lint-unordered-list-marker-style/package.json
@@ -12,7 +12,11 @@
     "list",
     "marker"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-unordered-list-marker-style",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint-unordered-list-marker-style"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-lint/package.json
+++ b/packages/remark-lint/package.json
@@ -13,7 +13,11 @@
     "lint",
     "validate"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-lint"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-preset-lint-consistent/package.json
+++ b/packages/remark-preset-lint-consistent/package.json
@@ -10,7 +10,11 @@
     "consistent",
     "consistency"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-preset-lint-consistent"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-preset-lint-markdown-style-guide/package.json
+++ b/packages/remark-preset-lint-markdown-style-guide/package.json
@@ -11,7 +11,11 @@
     "style",
     "guide"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-preset-lint-markdown-style-guide"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/remark-preset-lint-recommended/package.json
+++ b/packages/remark-preset-lint-recommended/package.json
@@ -9,7 +9,11 @@
     "preset",
     "recommended"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-recommended",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/remark-preset-lint-recommended"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/packages/unified-lint-rule/package.json
+++ b/packages/unified-lint-rule/package.json
@@ -10,7 +10,11 @@
     "lint",
     "rule"
   ],
-  "repository": "https://github.com/remarkjs/remark-lint/tree/main/packages/unified-lint-rule",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remarkjs/remark-lint",
+    "directory": "packages/unified-lint-rule"
+  },
   "bugs": "https://github.com/remarkjs/remark-lint/issues",
   "funding": {
     "type": "opencollective",

--- a/script/build-presets.js
+++ b/script/build-presets.js
@@ -14,16 +14,9 @@ import remarkGfm from 'remark-gfm'
 import strip from 'strip-indent'
 import parseAuthor from 'parse-author'
 import {presets} from './util/presets.js'
+import {repoUrl} from './util/repo-url.js'
 
-/** @type {PackageJson} */
-const pkg = JSON.parse(String(fs.readFileSync('package.json')))
-const remote = pkg.repository
-
-if (typeof remote !== 'string') {
-  throw new TypeError(
-    'Expected `string` for `repository` in root `package.json`'
-  )
-}
+const remote = repoUrl('package.json')
 
 const own = {}.hasOwnProperty
 

--- a/script/build-rules.js
+++ b/script/build-rules.js
@@ -14,19 +14,12 @@ import parseAuthor from 'parse-author'
 import {rules} from './util/rules.js'
 import {rule} from './util/rule.js'
 import {presets} from './util/presets.js'
+import {repoUrl} from './util/repo-url.js'
 import {characters} from './characters.js'
 
 const own = {}.hasOwnProperty
 
-/** @type {PackageJson} */
-const pkg = JSON.parse(String(fs.readFileSync('package.json')))
-const remote = pkg.repository
-
-if (typeof remote !== 'string') {
-  throw new TypeError(
-    'Expected `string` for `repository` in root `package.json`'
-  )
-}
+const remote = repoUrl('package.json')
 
 const root = path.join(process.cwd(), 'packages')
 

--- a/script/plugin/list-of-presets.js
+++ b/script/plugin/list-of-presets.js
@@ -10,6 +10,7 @@ import path from 'node:path'
 import process from 'node:process'
 import {zone} from 'mdast-zone'
 import {presets} from '../util/presets.js'
+import {repoUrl} from '../util/repo-url.js'
 
 const root = path.join(process.cwd(), 'packages')
 
@@ -46,7 +47,7 @@ export default function listOfPresets() {
                 children: [
                   {
                     type: 'link',
-                    url: String(pack.repository || ''),
+                    url: repoUrl(pack),
                     children: [{type: 'inlineCode', value: name}]
                   },
                   {type: 'text', value: ' — ' + description}

--- a/script/plugin/list-of-rules.js
+++ b/script/plugin/list-of-rules.js
@@ -10,6 +10,7 @@ import path from 'node:path'
 import process from 'node:process'
 import {zone} from 'mdast-zone'
 import {rules} from '../util/rules.js'
+import {repoUrl} from '../util/repo-url.js'
 
 const root = path.join(process.cwd(), 'packages')
 
@@ -43,7 +44,7 @@ export default function listOfRules() {
                 children: [
                   {
                     type: 'link',
-                    url: String(pack.repository || ''),
+                    url: repoUrl(pack),
                     children: [{type: 'inlineCode', value: name}]
                   },
                   {type: 'text', value: ' — ' + description}

--- a/script/util/repo-url.js
+++ b/script/util/repo-url.js
@@ -1,0 +1,38 @@
+import fs from 'node:fs'
+
+/**
+ * @typedef {import('type-fest').PackageJson} PackageJson
+ */
+
+/**
+ * @param {string | PackageJson} pathOrJson
+ * @returns {string}
+ */
+export function repoUrl(pathOrJson) {
+  const pkg =
+    typeof pathOrJson === 'string' ? readPackageJson(pathOrJson) : pathOrJson
+
+  if (
+    pkg.repository === undefined ||
+    typeof pkg.repository !== 'object' ||
+    typeof pkg.repository.url !== 'string'
+  ) {
+    throw new TypeError(
+      `Expected \`string\` for \`repository.url\` in \`${pathOrJson}\``
+    )
+  }
+
+  if (pkg.repository.directory) {
+    return pkg.repository.url + `/tree/main/${pkg.repository.directory}`
+  }
+
+  return pkg.repository.url
+}
+
+/**
+ * @param {string} filePath
+ * @returns {PackageJson}
+ */
+function readPackageJson(filePath) {
+  return JSON.parse(String(fs.readFileSync(filePath)))
+}


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This change updates the `repository` field in all the `package.json` files by the following Bash script.
https://gist.github.com/ybiquitous/48f69d29194ed1aecf9b85097da51715

For example:

```console
$ /tmp/update-repository.sh https://github.com/remarkjs/remark-lint
```

Also, this modifies the scripts to get the repository URLs.

Close #268

<!--do not edit: pr-->
