### PR TITLE
Add `url`s pointing to docs on all messages

### DIFF
--- a/packages/remark-lint-blockquote-indentation/index.js
+++ b/packages/remark-lint-blockquote-indentation/index.js
@@ -61,7 +61,10 @@ import {pointStart} from 'unist-util-position'
 import {generated} from 'unist-util-generated'
 
 const remarkLintBlockquoteIndentation = lintRule(
-  'remark-lint:blockquote-indentation',
+  {
+    origin: 'remark-lint:blockquote-indentation',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-blockquote-indentation#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = 'consistent') => {
     visit(tree, 'blockquote', (node) => {

--- a/packages/remark-lint-checkbox-character-style/index.js
+++ b/packages/remark-lint-checkbox-character-style/index.js
@@ -92,7 +92,10 @@ import {visit} from 'unist-util-visit'
 import {pointStart} from 'unist-util-position'
 
 const remarkLintCheckboxCharacterStyle = lintRule(
-  'remark-lint:checkbox-character-style',
+  {
+    origin: 'remark-lint:checkbox-character-style',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-checkbox-character-style#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = 'consistent') => {
     const value = String(file)

--- a/packages/remark-lint-checkbox-content-indent/index.js
+++ b/packages/remark-lint-checkbox-content-indent/index.js
@@ -40,7 +40,10 @@ import {visit} from 'unist-util-visit'
 import {pointStart} from 'unist-util-position'
 
 const remarkLintCheckboxContentIndent = lintRule(
-  'remark-lint:checkbox-content-indent',
+  {
+    origin: 'remark-lint:checkbox-content-indent',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-checkbox-content-indent#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     const value = String(file)

--- a/packages/remark-lint-code-block-style/index.js
+++ b/packages/remark-lint-code-block-style/index.js
@@ -113,7 +113,10 @@ import {pointStart, pointEnd} from 'unist-util-position'
 import {generated} from 'unist-util-generated'
 
 const remarkLintCodeBlockStyle = lintRule(
-  'remark-lint:code-block-style',
+  {
+    origin: 'remark-lint:code-block-style',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-code-block-style#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = 'consistent') => {
     const value = String(file)

--- a/packages/remark-lint-definition-case/index.js
+++ b/packages/remark-lint-definition-case/index.js
@@ -33,7 +33,10 @@ import {pointStart, pointEnd} from 'unist-util-position'
 const label = /^\s*\[((?:\\[\s\S]|[^[\]])+)]/
 
 const remarkLintDefinitionCase = lintRule(
-  'remark-lint:definition-case',
+  {
+    origin: 'remark-lint:definition-case',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-definition-case#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     const value = String(file)

--- a/packages/remark-lint-definition-spacing/index.js
+++ b/packages/remark-lint-definition-spacing/index.js
@@ -33,7 +33,10 @@ import {pointStart, pointEnd} from 'unist-util-position'
 const label = /^\s*\[((?:\\[\s\S]|[^[\]])+)]/
 
 const remarkLintDefinitionSpacing = lintRule(
-  'remark-lint:definition-spacing',
+  {
+    origin: 'remark-lint:definition-spacing',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-definition-spacing#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     const value = String(file)

--- a/packages/remark-lint-emphasis-marker/index.js
+++ b/packages/remark-lint-emphasis-marker/index.js
@@ -80,7 +80,10 @@ import {visit} from 'unist-util-visit'
 import {pointStart} from 'unist-util-position'
 
 const remarkLintEmphasisMarker = lintRule(
-  'remark-lint:emphasis-marker',
+  {
+    origin: 'remark-lint:emphasis-marker',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-emphasis-marker#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = 'consistent') => {
     const value = String(file)

--- a/packages/remark-lint-fenced-code-flag/index.js
+++ b/packages/remark-lint-fenced-code-flag/index.js
@@ -100,7 +100,10 @@ import {generated} from 'unist-util-generated'
 const fence = /^ {0,3}([~`])\1{2,}/
 
 const remarkLintFencedCodeFlag = lintRule(
-  'remark-lint:fenced-code-flag',
+  {
+    origin: 'remark-lint:fenced-code-flag',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-fenced-code-flag#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option) => {
     const value = String(file)

--- a/packages/remark-lint-fenced-code-marker/index.js
+++ b/packages/remark-lint-fenced-code-marker/index.js
@@ -100,7 +100,10 @@ import {visit} from 'unist-util-visit'
 import {pointStart} from 'unist-util-position'
 
 const remarkLintFencedCodeMarker = lintRule(
-  'remark-lint:fenced-code-marker',
+  {
+    origin: 'remark-lint:fenced-code-marker',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-fenced-code-marker#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = 'consistent') => {
     const contents = String(file)

--- a/packages/remark-lint-file-extension/index.js
+++ b/packages/remark-lint-file-extension/index.js
@@ -34,7 +34,10 @@
 import {lintRule} from 'unified-lint-rule'
 
 const remarkLintFileExtension = lintRule(
-  'remark-lint:file-extension',
+  {
+    origin: 'remark-lint:file-extension',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-file-extension#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (_, file, option = 'md') => {
     const ext = file.extname

--- a/packages/remark-lint-final-definition/index.js
+++ b/packages/remark-lint-final-definition/index.js
@@ -50,7 +50,10 @@ import {pointStart} from 'unist-util-position'
 import {generated} from 'unist-util-generated'
 
 const remarkLintFinalDefinition = lintRule(
-  'remark-lint:final-definition',
+  {
+    origin: 'remark-lint:final-definition',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-final-definition#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     let last = 0

--- a/packages/remark-lint-final-newline/index.js
+++ b/packages/remark-lint-final-newline/index.js
@@ -57,7 +57,10 @@
 import {lintRule} from 'unified-lint-rule'
 
 const remarkLintFinalNewline = lintRule(
-  'remark-lint:final-newline',
+  {
+    origin: 'remark-lint:final-newline',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-final-newline#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (_, file) => {
     const value = String(file)

--- a/packages/remark-lint-first-heading-level/index.js
+++ b/packages/remark-lint-first-heading-level/index.js
@@ -104,7 +104,10 @@ import {generated} from 'unist-util-generated'
 const re = /<h([1-6])/
 
 const remarkLintFirstHeadingLevel = lintRule(
-  'remark-lint:first-heading-level',
+  {
+    origin: 'remark-lint:first-heading-level',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-first-heading-level#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = 1) => {
     visit(tree, (node) => {

--- a/packages/remark-lint-hard-break-spaces/index.js
+++ b/packages/remark-lint-hard-break-spaces/index.js
@@ -34,7 +34,10 @@ import {pointStart, pointEnd} from 'unist-util-position'
 import {generated} from 'unist-util-generated'
 
 const remarkLintHardBreakSpaces = lintRule(
-  'remark-lint:hard-break-spaces',
+  {
+    origin: 'remark-lint:hard-break-spaces',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-hard-break-spaces#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     const value = String(file)

--- a/packages/remark-lint-heading-increment/index.js
+++ b/packages/remark-lint-heading-increment/index.js
@@ -36,7 +36,10 @@ import {visit} from 'unist-util-visit'
 import {generated} from 'unist-util-generated'
 
 const remarkLintHeadingIncrement = lintRule(
-  'remark-lint:heading-increment',
+  {
+    origin: 'remark-lint:heading-increment',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-heading-increment#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     /** @type {Depth} */

--- a/packages/remark-lint-heading-style/index.js
+++ b/packages/remark-lint-heading-style/index.js
@@ -88,7 +88,10 @@ import {headingStyle} from 'mdast-util-heading-style'
 import {generated} from 'unist-util-generated'
 
 const remarkLintHeadingStyle = lintRule(
-  'remark-lint:heading-style',
+  {
+    origin: 'remark-lint:heading-style',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-heading-style#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = 'consistent') => {
     if (

--- a/packages/remark-lint-linebreak-style/index.js
+++ b/packages/remark-lint-linebreak-style/index.js
@@ -63,7 +63,10 @@ import {location} from 'vfile-location'
 const escaped = {unix: '\\n', windows: '\\r\\n'}
 
 const remarkLintLinebreakStyle = lintRule(
-  'remark-lint:linebreak-style',
+  {
+    origin: 'remark-lint:linebreak-style',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-linebreak-style#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (_, file, option = 'consistent') => {
     const value = String(file)

--- a/packages/remark-lint-link-title-style/index.js
+++ b/packages/remark-lint-link-title-style/index.js
@@ -118,7 +118,10 @@ const markers = {
 }
 
 const remarkLintLinkTitleStyle = lintRule(
-  'remark-lint:link-title-style',
+  {
+    origin: 'remark-lint:link-title-style',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-link-title-style#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = 'consistent') => {
     const value = String(file)

--- a/packages/remark-lint-list-item-bullet-indent/index.js
+++ b/packages/remark-lint-list-item-bullet-indent/index.js
@@ -46,7 +46,10 @@ import plural from 'pluralize'
 import {visit} from 'unist-util-visit'
 
 const remarkLintListItemBulletIndent = lintRule(
-  'remark-lint:list-item-bullet-indent',
+  {
+    origin: 'remark-lint:list-item-bullet-indent',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-bullet-indent#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     visit(tree, 'list', (list, _, grandparent) => {

--- a/packages/remark-lint-list-item-content-indent/index.js
+++ b/packages/remark-lint-list-item-content-indent/index.js
@@ -34,7 +34,10 @@ import {visit} from 'unist-util-visit'
 import {pointStart} from 'unist-util-position'
 
 const remarkLintListItemContentIndent = lintRule(
-  'remark-lint:list-item-content-indent',
+  {
+    origin: 'remark-lint:list-item-content-indent',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-content-indent#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     const value = String(file)

--- a/packages/remark-lint-list-item-indent/index.js
+++ b/packages/remark-lint-list-item-indent/index.js
@@ -125,7 +125,10 @@ import {pointStart} from 'unist-util-position'
 import {generated} from 'unist-util-generated'
 
 const remarkLintListItemIndent = lintRule(
-  'remark-lint:list-item-indent',
+  {
+    origin: 'remark-lint:list-item-indent',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = 'tab-size') => {
     const value = String(file)

--- a/packages/remark-lint-list-item-spacing/index.js
+++ b/packages/remark-lint-list-item-spacing/index.js
@@ -127,7 +127,10 @@ import {pointStart, pointEnd} from 'unist-util-position'
 import {generated} from 'unist-util-generated'
 
 const remarkLintListItemSpacing = lintRule(
-  'remark-lint:list-item-spacing',
+  {
+    origin: 'remark-lint:list-item-spacing',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-spacing#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = {}) => {
     const {checkBlanks} = option

--- a/packages/remark-lint-maximum-heading-length/index.js
+++ b/packages/remark-lint-maximum-heading-length/index.js
@@ -39,7 +39,10 @@ import {generated} from 'unist-util-generated'
 import {toString} from 'mdast-util-to-string'
 
 const remarkLintMaximumHeadingLength = lintRule(
-  'remark-lint:maximum-heading-length',
+  {
+    origin: 'remark-lint:maximum-heading-length',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-maximum-heading-length#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = 60) => {
     visit(tree, 'heading', (node) => {

--- a/packages/remark-lint-maximum-line-length/index.js
+++ b/packages/remark-lint-maximum-line-length/index.js
@@ -108,7 +108,10 @@ import {pointStart, pointEnd} from 'unist-util-position'
 import {generated} from 'unist-util-generated'
 
 const remarkLintMaximumLineLength = lintRule(
-  'remark-lint:maximum-line-length',
+  {
+    origin: 'remark-lint:maximum-line-length',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-maximum-line-length#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = 80) => {
     const value = String(file)

--- a/packages/remark-lint-no-auto-link-without-protocol/index.js
+++ b/packages/remark-lint-no-auto-link-without-protocol/index.js
@@ -51,7 +51,10 @@ import {toString} from 'mdast-util-to-string'
 const protocol = /^[a-z][a-z+.-]+:\/?/i
 
 const remarkLintNoAutoLinkWithoutProtocol = lintRule(
-  'remark-lint:no-auto-link-without-protocol',
+  {
+    origin: 'remark-lint:no-auto-link-without-protocol',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-auto-link-without-protocol#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     visit(tree, 'link', (node) => {

--- a/packages/remark-lint-no-blockquote-without-marker/index.js
+++ b/packages/remark-lint-no-blockquote-without-marker/index.js
@@ -66,7 +66,10 @@ import {pointStart, pointEnd} from 'unist-util-position'
 import {generated} from 'unist-util-generated'
 
 const remarkLintNoBlockquoteWithoutMarker = lintRule(
-  'remark-lint:no-blockquote-without-marker',
+  {
+    origin: 'remark-lint:no-blockquote-without-marker',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-blockquote-without-marker#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     const value = String(file)

--- a/packages/remark-lint-no-consecutive-blank-lines/index.js
+++ b/packages/remark-lint-no-consecutive-blank-lines/index.js
@@ -56,7 +56,10 @@ import {pointStart, pointEnd} from 'unist-util-position'
 import {generated} from 'unist-util-generated'
 
 const remarkLintNoConsecutiveBlankLines = lintRule(
-  'remark-lint:no-consecutive-blank-lines',
+  {
+    origin: 'remark-lint:no-consecutive-blank-lines',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-consecutive-blank-lines#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     visit(tree, (node) => {

--- a/packages/remark-lint-no-duplicate-defined-urls/index.js
+++ b/packages/remark-lint-no-duplicate-defined-urls/index.js
@@ -35,7 +35,10 @@ import {stringifyPosition} from 'unist-util-stringify-position'
 import {visit} from 'unist-util-visit'
 
 const remarkLintNoDuplicateDefinedUrls = lintRule(
-  'remark-lint:no-duplicate-defined-urls',
+  {
+    origin: 'remark-lint:no-duplicate-defined-urls',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-duplicate-defined-urls#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     /** @type {Record<string, string>} */

--- a/packages/remark-lint-no-duplicate-definitions/index.js
+++ b/packages/remark-lint-no-duplicate-definitions/index.js
@@ -35,7 +35,10 @@ import {stringifyPosition} from 'unist-util-stringify-position'
 import {visit} from 'unist-util-visit'
 
 const remarkLintNoDuplicateDefinitions = lintRule(
-  'remark-lint:no-duplicate-definitions',
+  {
+    origin: 'remark-lint:no-duplicate-definitions',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-duplicate-definitions#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     /** @type {Record<string, string>} */

--- a/packages/remark-lint-no-duplicate-headings-in-section/index.js
+++ b/packages/remark-lint-no-duplicate-headings-in-section/index.js
@@ -72,7 +72,10 @@ import {stringifyPosition} from 'unist-util-stringify-position'
 import {toString} from 'mdast-util-to-string'
 
 const remarkLintNoDuplicateHeadingsInSection = lintRule(
-  'remark-lint:no-duplicate-headings-in-section',
+  {
+    origin: 'remark-lint:no-duplicate-headings-in-section',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-duplicate-headings-in-section#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     /** @type {Array.<Record<string, Heading>>} */

--- a/packages/remark-lint-no-duplicate-headings/index.js
+++ b/packages/remark-lint-no-duplicate-headings/index.js
@@ -41,7 +41,10 @@ import {stringifyPosition} from 'unist-util-stringify-position'
 import {toString} from 'mdast-util-to-string'
 
 const remarkLintNoDuplicateHeadings = lintRule(
-  'remark-lint:no-duplicate-headings',
+  {
+    origin: 'remark-lint:no-duplicate-headings',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-duplicate-headings#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     /** @type {Record<string, string>} */

--- a/packages/remark-lint-no-emphasis-as-heading/index.js
+++ b/packages/remark-lint-no-emphasis-as-heading/index.js
@@ -41,7 +41,10 @@ import {visit} from 'unist-util-visit'
 import {generated} from 'unist-util-generated'
 
 const remarkLintNoEmphasisAsHeading = lintRule(
-  'remark-lint:no-emphasis-as-heading',
+  {
+    origin: 'remark-lint:no-emphasis-as-heading',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-emphasis-as-heading#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     visit(tree, 'paragraph', (node, index, parent) => {

--- a/packages/remark-lint-no-empty-url/index.js
+++ b/packages/remark-lint-no-empty-url/index.js
@@ -36,7 +36,10 @@ import {visit} from 'unist-util-visit'
 import {generated} from 'unist-util-generated'
 
 const remarkLintNoEmptyUrl = lintRule(
-  'remark-lint:no-empty-url',
+  {
+    origin: 'remark-lint:no-empty-url',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-empty-url#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     visit(tree, (node) => {

--- a/packages/remark-lint-no-file-name-articles/index.js
+++ b/packages/remark-lint-no-file-name-articles/index.js
@@ -37,7 +37,10 @@
 import {lintRule} from 'unified-lint-rule'
 
 const remarkLintNoFileNameArticles = lintRule(
-  'remark-lint:no-file-name-articles',
+  {
+    origin: 'remark-lint:no-file-name-articles',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-file-name-articles#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (_, file) => {
     const match = file.stem && file.stem.match(/^(the|teh|an?)\b/i)

--- a/packages/remark-lint-no-file-name-consecutive-dashes/index.js
+++ b/packages/remark-lint-no-file-name-consecutive-dashes/index.js
@@ -22,7 +22,10 @@
 import {lintRule} from 'unified-lint-rule'
 
 const remarkLintNoFileNameConsecutiveDashes = lintRule(
-  'remark-lint:no-file-name-consecutive-dashes',
+  {
+    origin: 'remark-lint:no-file-name-consecutive-dashes',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-file-name-consecutive-dashes#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (_, file) => {
     if (file.stem && /-{2,}/.test(file.stem)) {

--- a/packages/remark-lint-no-file-name-irregular-characters/index.js
+++ b/packages/remark-lint-no-file-name-irregular-characters/index.js
@@ -48,7 +48,10 @@ import {lintRule} from 'unified-lint-rule'
 const expression = /[^\\.a-zA-Z\d-]/
 
 const remarkLintNoFileNameIrregularCharacters = lintRule(
-  'remark-lint:no-file-name-irregular-characters',
+  {
+    origin: 'remark-lint:no-file-name-irregular-characters',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-file-name-irregular-characters#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (_, file, option) => {
     let preferred = option || expression

--- a/packages/remark-lint-no-file-name-mixed-case/index.js
+++ b/packages/remark-lint-no-file-name-mixed-case/index.js
@@ -25,7 +25,10 @@
 import {lintRule} from 'unified-lint-rule'
 
 const remarkLintNofileNameMixedCase = lintRule(
-  'remark-lint:no-file-name-mixed-case',
+  {
+    origin: 'remark-lint:no-file-name-mixed-case',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-file-name-mixed-case#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (_, file) => {
     const name = file.stem

--- a/packages/remark-lint-no-file-name-outer-dashes/index.js
+++ b/packages/remark-lint-no-file-name-outer-dashes/index.js
@@ -27,7 +27,10 @@
 import {lintRule} from 'unified-lint-rule'
 
 const remarkLintNofileNameOuterDashes = lintRule(
-  'remark-lint:no-file-name-outer-dashes',
+  {
+    origin: 'remark-lint:no-file-name-outer-dashes',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-file-name-outer-dashes#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (_, file) => {
     if (file.stem && /^-|-$/.test(file.stem)) {

--- a/packages/remark-lint-no-heading-content-indent/index.js
+++ b/packages/remark-lint-no-heading-content-indent/index.js
@@ -62,7 +62,10 @@ import {pointStart, pointEnd} from 'unist-util-position'
 import {generated} from 'unist-util-generated'
 
 const remarkLintNoHeadingContentIndent = lintRule(
-  'remark-lint:no-heading-content-indent',
+  {
+    origin: 'remark-lint:no-heading-content-indent',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-heading-content-indent#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     visit(tree, 'heading', (node) => {

--- a/packages/remark-lint-no-heading-indent/index.js
+++ b/packages/remark-lint-no-heading-indent/index.js
@@ -60,7 +60,10 @@ import {pointStart} from 'unist-util-position'
 import {generated} from 'unist-util-generated'
 
 const remarkLintNoHeadingIndent = lintRule(
-  'remark-lint:no-heading-indent',
+  {
+    origin: 'remark-lint:no-heading-indent',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-heading-indent#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     visit(tree, 'heading', (node, _, parent) => {

--- a/packages/remark-lint-no-heading-like-paragraph/index.js
+++ b/packages/remark-lint-no-heading-like-paragraph/index.js
@@ -37,7 +37,10 @@ import {generated} from 'unist-util-generated'
 const fence = '#######'
 
 const remarkLintNoHeadingLikeParagraph = lintRule(
-  'remark-lint:no-heading-like-paragraph',
+  {
+    origin: 'remark-lint:no-heading-like-paragraph',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-heading-like-paragraph#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     visit(tree, 'paragraph', (node) => {

--- a/packages/remark-lint-no-heading-punctuation/index.js
+++ b/packages/remark-lint-no-heading-punctuation/index.js
@@ -55,7 +55,10 @@ import {generated} from 'unist-util-generated'
 import {toString} from 'mdast-util-to-string'
 
 const remarkLintNoHeadingPunctuation = lintRule(
-  'remark-lint:no-heading-punctuation',
+  {
+    origin: 'remark-lint:no-heading-punctuation',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-heading-punctuation#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = '\\.,;:!?') => {
     const expression = new RegExp('[' + option + ']')

--- a/packages/remark-lint-no-html/index.js
+++ b/packages/remark-lint-no-html/index.js
@@ -36,7 +36,10 @@ import {visit} from 'unist-util-visit'
 import {generated} from 'unist-util-generated'
 
 const remarkLintNoHtml = lintRule(
-  'remark-lint:no-html',
+  {
+    origin: 'remark-lint:no-html',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-html#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     visit(tree, 'html', (node) => {

--- a/packages/remark-lint-no-inline-padding/index.js
+++ b/packages/remark-lint-no-inline-padding/index.js
@@ -35,7 +35,10 @@ import {generated} from 'unist-util-generated'
 import {toString} from 'mdast-util-to-string'
 
 const remarkLintNoInlinePadding = lintRule(
-  'remark-lint:no-inline-padding',
+  {
+    origin: 'remark-lint:no-inline-padding',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-inline-padding#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     // Note: `emphasis`, `strong`, `delete` (GFM) can’t have padding anymore

--- a/packages/remark-lint-no-literal-urls/index.js
+++ b/packages/remark-lint-no-literal-urls/index.js
@@ -45,7 +45,10 @@ import {generated} from 'unist-util-generated'
 import {toString} from 'mdast-util-to-string'
 
 const remarkLintNoLiteralUrls = lintRule(
-  'remark-lint:no-literal-urls',
+  {
+    origin: 'remark-lint:no-literal-urls',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-literal-urls#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     visit(tree, 'link', (node) => {

--- a/packages/remark-lint-no-missing-blank-lines/index.js
+++ b/packages/remark-lint-no-missing-blank-lines/index.js
@@ -93,7 +93,10 @@ const types = new Set([
 ])
 
 const remarkLintNoMissingBlankLines = lintRule(
-  'remark-lint:no-missing-blank-lines',
+  {
+    origin: 'remark-lint:no-missing-blank-lines',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-missing-blank-lines#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = {}) => {
     const {exceptTightLists} = option

--- a/packages/remark-lint-no-multiple-toplevel-headings/index.js
+++ b/packages/remark-lint-no-multiple-toplevel-headings/index.js
@@ -41,7 +41,10 @@ import {generated} from 'unist-util-generated'
 import {stringifyPosition} from 'unist-util-stringify-position'
 
 const remarkLintNoMultipleToplevelHeadings = lintRule(
-  'remark-lint:no-multiple-toplevel-headings',
+  {
+    origin: 'remark-lint:no-multiple-toplevel-headings',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-multiple-toplevel-headings#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = 1) => {
     /** @type {string|undefined} */

--- a/packages/remark-lint-no-paragraph-content-indent/index.js
+++ b/packages/remark-lint-no-paragraph-content-indent/index.js
@@ -84,7 +84,10 @@ import {pointStart, pointEnd} from 'unist-util-position'
 import {location} from 'vfile-location'
 
 const remarkLintNoParagraphContentIndent = lintRule(
-  'remark-lint:no-paragraph-content-indent',
+  {
+    origin: 'remark-lint:no-paragraph-content-indent',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-paragraph-content-indent#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     const value = String(file)

--- a/packages/remark-lint-no-reference-like-url/index.js
+++ b/packages/remark-lint-no-reference-like-url/index.js
@@ -35,7 +35,10 @@ import {generated} from 'unist-util-generated'
 import {visit} from 'unist-util-visit'
 
 const remarkLintNoReferenceLikeUrl = lintRule(
-  'remark-lint:no-reference-like-url',
+  {
+    origin: 'remark-lint:no-reference-like-url',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-reference-like-url#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     /** @type {string[]} */

--- a/packages/remark-lint-no-shell-dollars/index.js
+++ b/packages/remark-lint-no-shell-dollars/index.js
@@ -81,7 +81,10 @@ const flags = new Set([
 ])
 
 const remarkLintNoShellDollars = lintRule(
-  'remark-lint:no-shell-dollars',
+  {
+    origin: 'remark-lint:no-shell-dollars',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-shell-dollars#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     visit(tree, 'code', (node) => {

--- a/packages/remark-lint-no-shortcut-reference-image/index.js
+++ b/packages/remark-lint-no-shortcut-reference-image/index.js
@@ -41,7 +41,10 @@ import {visit} from 'unist-util-visit'
 import {generated} from 'unist-util-generated'
 
 const remarkLintNoShortcutReferenceImage = lintRule(
-  'remark-lint:no-shortcut-reference-image',
+  {
+    origin: 'remark-lint:no-shortcut-reference-image',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-shortcut-reference-image#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     visit(tree, 'imageReference', (node) => {

--- a/packages/remark-lint-no-shortcut-reference-link/index.js
+++ b/packages/remark-lint-no-shortcut-reference-link/index.js
@@ -41,7 +41,10 @@ import {visit} from 'unist-util-visit'
 import {generated} from 'unist-util-generated'
 
 const remarkLintNoShortcutReferenceLink = lintRule(
-  'remark-lint:no-shortcut-reference-link',
+  {
+    origin: 'remark-lint:no-shortcut-reference-link',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-shortcut-reference-link#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     visit(tree, 'linkReference', (node) => {

--- a/packages/remark-lint-no-table-indentation/index.js
+++ b/packages/remark-lint-no-table-indentation/index.js
@@ -74,7 +74,10 @@ import {pointStart, pointEnd} from 'unist-util-position'
 import {location} from 'vfile-location'
 
 const remarkLintNoTableIndentation = lintRule(
-  'remark-lint:no-table-indentation',
+  {
+    origin: 'remark-lint:no-table-indentation',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-table-indentation#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     const value = String(file)

--- a/packages/remark-lint-no-tabs/index.js
+++ b/packages/remark-lint-no-tabs/index.js
@@ -61,7 +61,10 @@ import {lintRule} from 'unified-lint-rule'
 import {location} from 'vfile-location'
 
 const remarkLintNoTabs = lintRule(
-  'remark-lint:no-tabs',
+  {
+    origin: 'remark-lint:no-tabs',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-tabs#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (_, file) => {
     const value = String(file)

--- a/packages/remark-lint-no-undefined-references/index.js
+++ b/packages/remark-lint-no-undefined-references/index.js
@@ -85,7 +85,10 @@ import {pointStart, pointEnd} from 'unist-util-position'
 import {visit, SKIP, EXIT} from 'unist-util-visit'
 
 const remarkLintNoUndefinedReferences = lintRule(
-  'remark-lint:no-undefined-references',
+  {
+    origin: 'remark-lint:no-undefined-references',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-undefined-references#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = {}) => {
     const contents = String(file)

--- a/packages/remark-lint-no-unneeded-full-reference-image/index.js
+++ b/packages/remark-lint-no-unneeded-full-reference-image/index.js
@@ -51,7 +51,10 @@ import {generated} from 'unist-util-generated'
 import {normalizeIdentifier} from 'micromark-util-normalize-identifier'
 
 const remarkLintNoUnneededFullReferenceImage = lintRule(
-  'remark-lint:no-unneeded-full-reference-image',
+  {
+    origin: 'remark-lint:no-unneeded-full-reference-image',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-unneeded-full-reference-image#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     visit(tree, 'imageReference', (node) => {

--- a/packages/remark-lint-no-unneeded-full-reference-link/index.js
+++ b/packages/remark-lint-no-unneeded-full-reference-link/index.js
@@ -56,7 +56,10 @@ import {generated} from 'unist-util-generated'
 import {normalizeIdentifier} from 'micromark-util-normalize-identifier'
 
 const remarkLintNoUnneededFullReferenceLink = lintRule(
-  'remark-lint:no-unneeded-full-reference-link',
+  {
+    origin: 'remark-lint:no-unneeded-full-reference-link',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-unneeded-full-reference-link#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     visit(tree, 'linkReference', (node) => {

--- a/packages/remark-lint-no-unused-definitions/index.js
+++ b/packages/remark-lint-no-unused-definitions/index.js
@@ -36,7 +36,10 @@ import {visit} from 'unist-util-visit'
 const own = {}.hasOwnProperty
 
 const remarkLintNoUnusedDefinitions = lintRule(
-  'remark-lint:no-unused-definitions',
+  {
+    origin: 'remark-lint:no-unused-definitions',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-unused-definitions#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     /** @type {Record<string, {node: DefinitionContent, used: boolean}>} */

--- a/packages/remark-lint-ordered-list-marker-style/index.js
+++ b/packages/remark-lint-ordered-list-marker-style/index.js
@@ -67,7 +67,10 @@ import {pointStart} from 'unist-util-position'
 import {generated} from 'unist-util-generated'
 
 const remarkLintOrderedListMarkerStyle = lintRule(
-  'remark-lint:ordered-list-marker-style',
+  {
+    origin: 'remark-lint:ordered-list-marker-style',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-style#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = 'consistent') => {
     const value = String(file)

--- a/packages/remark-lint-ordered-list-marker-value/index.js
+++ b/packages/remark-lint-ordered-list-marker-value/index.js
@@ -148,7 +148,10 @@ import {pointStart} from 'unist-util-position'
 import {generated} from 'unist-util-generated'
 
 const remarkLintOrderedListMarkerValue = lintRule(
-  'remark-lint:ordered-list-marker-value',
+  {
+    origin: 'remark-lint:ordered-list-marker-value',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-value#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = 'ordered') => {
     const value = String(file)

--- a/packages/remark-lint-rule-style/index.js
+++ b/packages/remark-lint-rule-style/index.js
@@ -70,7 +70,10 @@ import {visit} from 'unist-util-visit'
 import {pointStart, pointEnd} from 'unist-util-position'
 
 const remarkLintRuleStyle = lintRule(
-  'remark-lint:rule-style',
+  {
+    origin: 'remark-lint:rule-style',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-rule-style#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = 'consistent') => {
     const value = String(file)

--- a/packages/remark-lint-strikethrough-marker/index.js
+++ b/packages/remark-lint-strikethrough-marker/index.js
@@ -74,7 +74,10 @@ import {visit} from 'unist-util-visit'
 import {pointStart} from 'unist-util-position'
 
 const remarkLintStrikethroughMarker = lintRule(
-  'remark-lint:strikethrough-marker',
+  {
+    origin: 'remark-lint:strikethrough-marker',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-strikethrough-marker#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = 'consistent') => {
     const value = String(file)

--- a/packages/remark-lint-strong-marker/index.js
+++ b/packages/remark-lint-strong-marker/index.js
@@ -69,7 +69,10 @@ import {visit} from 'unist-util-visit'
 import {pointStart} from 'unist-util-position'
 
 const remarkLintStrongMarker = lintRule(
-  'remark-lint:strong-marker',
+  {
+    origin: 'remark-lint:strong-marker',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-strong-marker#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = 'consistent') => {
     const value = String(file)

--- a/packages/remark-lint-table-cell-padding/index.js
+++ b/packages/remark-lint-table-cell-padding/index.js
@@ -189,7 +189,10 @@ import {visit, SKIP} from 'unist-util-visit'
 import {pointStart, pointEnd} from 'unist-util-position'
 
 const remarkLintTableCellPadding = lintRule(
-  'remark-lint:table-cell-padding',
+  {
+    origin: 'remark-lint:table-cell-padding',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-table-cell-padding#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = 'consistent') => {
     if (

--- a/packages/remark-lint-table-pipe-alignment/index.js
+++ b/packages/remark-lint-table-pipe-alignment/index.js
@@ -57,7 +57,10 @@ import {visit} from 'unist-util-visit'
 import {pointStart, pointEnd} from 'unist-util-position'
 
 const remarkLintTablePipeAlignment = lintRule(
-  'remark-lint:table-pipe-alignment',
+  {
+    origin: 'remark-lint:table-pipe-alignment',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-table-pipe-alignment#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     const value = String(file)

--- a/packages/remark-lint-table-pipes/index.js
+++ b/packages/remark-lint-table-pipes/index.js
@@ -49,7 +49,10 @@ const reasonStart = 'Missing initial pipe in table fence'
 const reasonEnd = 'Missing final pipe in table fence'
 
 const remarkLintTablePipes = lintRule(
-  'remark-lint:table-pipes',
+  {
+    origin: 'remark-lint:table-pipes',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-table-pipes#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, void>} */
   (tree, file) => {
     const value = String(file)

--- a/packages/remark-lint-unordered-list-marker-style/index.js
+++ b/packages/remark-lint-unordered-list-marker-style/index.js
@@ -87,7 +87,10 @@ import {generated} from 'unist-util-generated'
 const markers = new Set(['-', '*', '+'])
 
 const remarkLintUnorderedListMarkerStyle = lintRule(
-  'remark-lint:unordered-list-marker-style',
+  {
+    origin: 'remark-lint:unordered-list-marker-style',
+    url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-unordered-list-marker-style#readme'
+  },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   (tree, file, option = 'consistent') => {
     const value = String(file)

--- a/packages/unified-lint-rule/index.d.ts
+++ b/packages/unified-lint-rule/index.d.ts
@@ -12,7 +12,7 @@ export interface RuleMeta {
   /**
    * Link to documentation
    */
-  url?: string
+  url?: string | undefined
 }
 
 export function lintRule<Tree extends Node = Node, Settings = unknown>(

--- a/packages/unified-lint-rule/index.d.ts
+++ b/packages/unified-lint-rule/index.d.ts
@@ -3,8 +3,13 @@ import type {VFile} from 'vfile'
 import type {Plugin} from 'unified'
 import type {Label, Severity} from './lib/index.js'
 
+export interface RuleMeta {
+  origin: string
+  url?: string
+}
+
 export function lintRule<Tree extends Node = Node, Settings = unknown>(
-  name: string,
+  name: string | RuleMeta,
   rule: Rule<Tree, Settings>
 ): Plugin<
   | void[]

--- a/packages/unified-lint-rule/index.d.ts
+++ b/packages/unified-lint-rule/index.d.ts
@@ -4,7 +4,13 @@ import type {Plugin} from 'unified'
 import type {Label, Severity} from './lib/index.js'
 
 export interface RuleMeta {
+  /**
+   * name of the lint rule
+   */
   origin: string
+  /**
+   * link to documentation
+   */
   url?: string
 }
 

--- a/packages/unified-lint-rule/index.d.ts
+++ b/packages/unified-lint-rule/index.d.ts
@@ -5,11 +5,12 @@ import type {Label, Severity} from './lib/index.js'
 
 export interface RuleMeta {
   /**
-   * name of the lint rule
+   * Name of the lint rule
    */
   origin: string
+
   /**
-   * link to documentation
+   * Link to documentation
    */
   url?: string
 }

--- a/packages/unified-lint-rule/lib/index.js
+++ b/packages/unified-lint-rule/lib/index.js
@@ -6,7 +6,9 @@
  * @typedef {'warn'|'on'|'off'|'error'} Label
  * @typedef {[Severity, ...unknown[]]} SeverityTuple
  *
- * @typedef {{origin: string; url?: string;}} RuleMeta
+ * @typedef RuleMeta
+ * @property {string} origin name of the lint rule
+ * @property {string} [url] link to documentation
  *
  * @callback Rule
  * @param {Node} tree

--- a/packages/unified-lint-rule/lib/index.js
+++ b/packages/unified-lint-rule/lib/index.js
@@ -6,6 +6,8 @@
  * @typedef {'warn'|'on'|'off'|'error'} Label
  * @typedef {[Severity, ...unknown[]]} SeverityTuple
  *
+ * @typedef {{origin: string; url?: string;}} RuleMeta
+ *
  * @callback Rule
  * @param {Node} tree
  * @param {VFile} file
@@ -18,10 +20,12 @@ import {wrap} from 'trough'
 const primitives = new Set(['string', 'number', 'boolean'])
 
 /**
- * @param {string} id
+ * @param {string|RuleMeta} meta
  * @param {Rule} rule
  */
-export function lintRule(id, rule) {
+export function lintRule(meta, rule) {
+  const id = typeof meta === 'string' ? meta : meta.origin
+  const url = typeof meta === 'string' ? undefined : meta.url
   const parts = id.split(':')
   // Possibly useful if externalised later.
   /* c8 ignore next */
@@ -57,7 +61,7 @@ export function lintRule(id, rule) {
         }
 
         while (++index < messages.length) {
-          Object.assign(messages[index], {ruleId, source, fatal})
+          Object.assign(messages[index], {ruleId, source, fatal, url})
         }
 
         next()

--- a/script/util/rule.js
+++ b/script/util/rule.js
@@ -82,7 +82,7 @@ export function rule(filePath) {
       info = JSON.parse(lines[0])
       lines.splice(0, 1)
       /* c8 ignore next 5 */
-    } catch (error) {
+    } catch (/** @type any */ error) {
       throw new Error(
         'Could not parse example in ' + ruleId + ':\n' + error.stack
       )

--- a/script/util/rule.js
+++ b/script/util/rule.js
@@ -81,10 +81,11 @@ export function rule(filePath) {
     try {
       info = JSON.parse(lines[0])
       lines.splice(0, 1)
-      /* c8 ignore next 5 */
-    } catch (/** @type any */ error) {
+      /* c8 ignore next 6 */
+    } catch (error) {
+      const exception = /** @type Error */ (error)
       throw new Error(
-        'Could not parse example in ' + ruleId + ':\n' + error.stack
+        'Could not parse example in ' + ruleId + ':\n' + exception.stack
       )
     }
 

--- a/test.js
+++ b/test.js
@@ -14,6 +14,7 @@ import {toVFile} from 'to-vfile'
 import {removePosition} from 'unist-util-remove-position'
 import {remark} from 'remark'
 import remarkGfm from 'remark-gfm'
+import {lintRule} from 'unified-lint-rule'
 import {rules} from './script/util/rules.js'
 import {rule} from './script/util/rule.js'
 import {characters} from './script/characters.js'
@@ -94,6 +95,7 @@ test('core', async (t) => {
         column: null,
         source: 'remark-lint',
         ruleId: 'final-newline',
+        url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-final-newline#readme',
         position: {
           start: {line: null, column: null},
           end: {line: null, column: null}
@@ -143,6 +145,7 @@ test('core', async (t) => {
         column: null,
         source: 'remark-lint',
         ruleId: 'final-newline',
+        url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-final-newline#readme',
         position: {
           start: {line: null, column: null},
           end: {line: null, column: null}
@@ -166,6 +169,7 @@ test('core', async (t) => {
         column: null,
         source: 'remark-lint',
         ruleId: 'final-newline',
+        url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-final-newline#readme',
         position: {
           start: {line: null, column: null},
           end: {line: null, column: null}
@@ -189,6 +193,7 @@ test('core', async (t) => {
         column: null,
         source: 'remark-lint',
         ruleId: 'final-newline',
+        url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-final-newline#readme',
         position: {
           start: {line: null, column: null},
           end: {line: null, column: null}
@@ -221,6 +226,36 @@ test('core', async (t) => {
     },
     /^Error: Incorrect severity `-1` for `final-newline`, expected 0, 1, or 2$/,
     'should fail on incorrect severities (too low)'
+  )
+
+  t.deepEqual(
+    (
+      await remark()
+        .use(
+          lintRule('test:rule', (tree, file) => {
+            file.message('Test message')
+          }),
+          ['warn']
+        )
+        .process('.')
+    ).messages.map((d) => JSON.parse(JSON.stringify(d))),
+    [
+      {
+        name: '1:1',
+        message: 'Test message',
+        reason: 'Test message',
+        line: null,
+        column: null,
+        source: 'test',
+        ruleId: 'rule',
+        position: {
+          start: {line: null, column: null},
+          end: {line: null, column: null}
+        },
+        fatal: false
+      }
+    ],
+    'should support string meta'
   )
 })
 

--- a/test.js
+++ b/test.js
@@ -368,6 +368,21 @@ function assertFixture(t, rule, info, fixture, basename, settings) {
           message
       )
     }
+
+    const expectedUrl =
+      'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-' +
+      ruleId +
+      '#readme'
+    if (message.url !== expectedUrl) {
+      throw new Error(
+        'Expected `' +
+          expectedUrl +
+          '`, not `' +
+          message.url +
+          '` as `ruleId` for ' +
+          message
+      )
+    }
   }
 
   t.deepEqual(normalize(file.messages), expected, 'should equal with position')

--- a/test.js
+++ b/test.js
@@ -349,9 +349,10 @@ function assertFixture(t, rule, info, fixture, basename, settings) {
 
   try {
     proc.runSync(proc.parse(file), file)
-  } catch (/** @type any */ error) {
-    if (error && error.source !== 'remark-lint') {
-      throw error
+  } catch (error) {
+    const exception = /** @type VFileMessage */ (error)
+    if (exception && exception.source !== 'remark-lint') {
+      throw exception
     }
   }
 

--- a/test.js
+++ b/test.js
@@ -314,7 +314,7 @@ function assertFixture(t, rule, info, fixture, basename, settings) {
 
   try {
     proc.runSync(proc.parse(file), file)
-  } catch (error) {
+  } catch (/** @type any */ error) {
     if (error && error.source !== 'remark-lint') {
       throw error
     }


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Allow `unified-lint-rule` to accept an object instead of a source string, which can specify named properties, including `source` and `url`. The `url` is set on all reported vfile messages.

All `remark-lint` rules have been updated to use an object and set the `url`.

Closes #272

<!--do not edit: pr-->
