### PR TITLE
Give rules access to settings

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -7,6 +7,7 @@ import remarkGithub from 'remark-github'
 import remarkValidateLinks from 'remark-validate-links'
 import listOfPresets from './script/plugin/list-of-presets.js'
 import listOfRules from './script/plugin/list-of-rules.js'
+import listOfSettings from './script/plugin/list-of-settings.js'
 
 const plugins = [
   remarkPresetLintRecommended,
@@ -17,7 +18,8 @@ const plugins = [
   remarkGithub,
   remarkValidateLinks,
   listOfPresets,
-  listOfRules
+  listOfRules,
+  listOfSettings
 ]
 
 const preset = {plugins}

--- a/packages/remark-lint-code-block-style/index.js
+++ b/packages/remark-lint-code-block-style/index.js
@@ -49,6 +49,15 @@
  * @license MIT
  *
  * @example
+ *   {"config": "indented", "name": "ok.md"}
+ *
+ *       alpha()
+ *
+ *   Paragraph.
+ *
+ *       bravo()
+ *
+ * @example
  *   {"settings": {"fences": false}, "name": "ok.md"}
  *
  *       alpha()
@@ -56,6 +65,25 @@
  *   Paragraph.
  *
  *       bravo()
+ *
+ * @example
+ *   {"config": "indented", "name": "not-ok.md", "label": "input"}
+ *
+ *   ```
+ *   alpha()
+ *   ```
+ *
+ *   Paragraph.
+ *
+ *   ```
+ *   bravo()
+ *   ```
+ *
+ * @example
+ *   {"config": "indented", "name": "not-ok.md", "label": "output"}
+ *
+ *   1:1-3:4: Code blocks should be indented
+ *   7:1-9:4: Code blocks should be indented
  *
  * @example
  *   {"settings": {"fences": false}, "name": "not-ok.md", "label": "input"}
@@ -77,6 +105,19 @@
  *   7:1-9:4: Code blocks should be indented
  *
  * @example
+ *   {"config": "fenced", "name": "ok.md"}
+ *
+ *   ```
+ *   alpha()
+ *   ```
+ *
+ *   Paragraph.
+ *
+ *   ```
+ *   bravo()
+ *   ```
+ *
+ * @example
  *   {"settings": {"fences": true}, "name": "ok.md"}
  *
  *   ```
@@ -88,6 +129,21 @@
  *   ```
  *   bravo()
  *   ```
+ *
+ * @example
+ *   {"config": "fenced", "name": "not-ok-fenced.md", "label": "input"}
+ *
+ *       alpha()
+ *
+ *   Paragraph.
+ *
+ *       bravo()
+ *
+ * @example
+ *   {"config": "fenced", "name": "not-ok-fenced.md", "label": "output"}
+ *
+ *   1:1-1:12: Code blocks should be fenced
+ *   5:1-5:12: Code blocks should be fenced
  *
  * @example
  *   {"settings": {"fences": true}, "name": "not-ok-fenced.md", "label": "input"}

--- a/packages/remark-lint-code-block-style/index.js
+++ b/packages/remark-lint-code-block-style/index.js
@@ -5,7 +5,7 @@
  *
  * ## API
  *
- * The following options (default: `'consistent'`) are accepted:
+ * The following options (default: [`settings.fences`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences) or `'consistent'`) are accepted:
  *
  * *   `'fenced'`
  *     — prefer fenced code blocks:
@@ -49,7 +49,7 @@
  * @license MIT
  *
  * @example
- *   {"config": "indented", "name": "ok.md"}
+ *   {"settings": {"fences": false}, "name": "ok.md"}
  *
  *       alpha()
  *
@@ -58,7 +58,7 @@
  *       bravo()
  *
  * @example
- *   {"config": "indented", "name": "not-ok.md", "label": "input"}
+ *   {"settings": {"fences": false}, "name": "not-ok.md", "label": "input"}
  *
  *   ```
  *   alpha()
@@ -71,13 +71,13 @@
  *   ```
  *
  * @example
- *   {"config": "indented", "name": "not-ok.md", "label": "output"}
+ *   {"settings": {"fences": false}, "name": "not-ok.md", "label": "output"}
  *
  *   1:1-3:4: Code blocks should be indented
  *   7:1-9:4: Code blocks should be indented
  *
  * @example
- *   {"config": "fenced", "name": "ok.md"}
+ *   {"settings": {"fences": true}, "name": "ok.md"}
  *
  *   ```
  *   alpha()
@@ -90,7 +90,7 @@
  *   ```
  *
  * @example
- *   {"config": "fenced", "name": "not-ok-fenced.md", "label": "input"}
+ *   {"settings": {"fences": true}, "name": "not-ok-fenced.md", "label": "input"}
  *
  *       alpha()
  *
@@ -99,7 +99,7 @@
  *       bravo()
  *
  * @example
- *   {"config": "fenced", "name": "not-ok-fenced.md", "label": "output"}
+ *   {"settings": {"fences": true}, "name": "not-ok-fenced.md", "label": "output"}
  *
  *   1:1-1:12: Code blocks should be fenced
  *   5:1-5:12: Code blocks should be fenced
@@ -143,8 +143,18 @@ const remarkLintCodeBlockStyle = lintRule(
     url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-code-block-style#readme'
   },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
-  (tree, file, option = 'consistent') => {
+  function (tree, file, option) {
     const value = String(file)
+
+    if (!option) {
+      const {settings} = this.data()
+      option =
+        !settings || settings.fences === undefined
+          ? 'consistent'
+          : settings.fences
+          ? 'fenced'
+          : 'indented'
+    }
 
     if (
       option !== 'consistent' &&

--- a/packages/remark-lint-code-block-style/index.js
+++ b/packages/remark-lint-code-block-style/index.js
@@ -203,13 +203,14 @@ const remarkLintCodeBlockStyle = lintRule(
     const value = String(file)
 
     if (!option) {
-      const {settings} = this.data()
+      /** @type {import('remark-stringify').Options} */
+      const settings = this.data().settings || {}
       option =
-        !settings || settings.fences === undefined
-          ? 'consistent'
-          : settings.fences
+        settings.fences === true
           ? 'fenced'
-          : 'indented'
+          : settings.fences === false
+          ? 'indented'
+          : 'consistent'
     }
 
     if (

--- a/packages/remark-lint-code-block-style/index.js
+++ b/packages/remark-lint-code-block-style/index.js
@@ -5,7 +5,7 @@
  *
  * ## API
  *
- * The following options (default: [`settings.fences`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences) or `'consistent'`) are accepted:
+ * The following options (default: [`settings.fences`](https://github.com/remarkjs/remark-lint#configure) or `'consistent'`) are accepted:
  *
  * *   `'fenced'`
  *     — prefer fenced code blocks:
@@ -37,8 +37,8 @@
  * [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
  * formats code blocks as fenced code when they have a language flag and as
  * indented code otherwise.
- * Pass
- * [`fences: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences)
+ * Change
+ * [`settings.fences`](https://github.com/remarkjs/remark-lint#configure) to `true`
  * to always use fenced code.
  *
  * @module code-block-style

--- a/packages/remark-lint-code-block-style/readme.md
+++ b/packages/remark-lint-code-block-style/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'fenced'` |
 
 ## Install
 

--- a/packages/remark-lint-code-block-style/readme.md
+++ b/packages/remark-lint-code-block-style/readme.md
@@ -207,7 +207,7 @@ bravo()
 
 ##### `ok.md`
 
-When configured with [`settings.fences: false`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences).
+When [`settings.fences`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences) is `false` and the rule is not configured.
 
 ###### In
 
@@ -225,7 +225,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with [`settings.fences: false`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences).
+When [`settings.fences`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences) is `false` and the rule is not configured.
 
 ###### In
 
@@ -293,7 +293,7 @@ Paragraph.
 
 ##### `ok.md`
 
-When configured with [`settings.fences: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences).
+When [`settings.fences`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences) is `true` and the rule is not configured.
 
 ###### In
 
@@ -315,7 +315,7 @@ No messages.
 
 ##### `not-ok-fenced.md`
 
-When configured with [`settings.fences: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences).
+When [`settings.fences`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences) is `true` and the rule is not configured.
 
 ###### In
 

--- a/packages/remark-lint-code-block-style/readme.md
+++ b/packages/remark-lint-code-block-style/readme.md
@@ -164,6 +164,49 @@ to always use fenced code.
 
 ##### `ok.md`
 
+When configured with `'indented'`.
+
+###### In
+
+```markdown
+    alpha()
+
+Paragraph.
+
+    bravo()
+```
+
+###### Out
+
+No messages.
+
+##### `not-ok.md`
+
+When configured with `'indented'`.
+
+###### In
+
+````markdown
+```
+alpha()
+```
+
+Paragraph.
+
+```
+bravo()
+```
+````
+
+###### Out
+
+```text
+1:1-3:4: Code blocks should be indented
+7:1-9:4: Code blocks should be indented
+```
+
+##### `ok.md`
+
 When configured with [`settings.fences: false`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences).
 
 ###### In
@@ -203,6 +246,49 @@ bravo()
 ```text
 1:1-3:4: Code blocks should be indented
 7:1-9:4: Code blocks should be indented
+```
+
+##### `ok.md`
+
+When configured with `'fenced'`.
+
+###### In
+
+````markdown
+```
+alpha()
+```
+
+Paragraph.
+
+```
+bravo()
+```
+````
+
+###### Out
+
+No messages.
+
+##### `not-ok-fenced.md`
+
+When configured with `'fenced'`.
+
+###### In
+
+```markdown
+    alpha()
+
+Paragraph.
+
+    bravo()
+```
+
+###### Out
+
+```text
+1:1-1:12: Code blocks should be fenced
+5:1-5:12: Code blocks should be fenced
 ```
 
 ##### `ok.md`

--- a/packages/remark-lint-code-block-style/readme.md
+++ b/packages/remark-lint-code-block-style/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'fenced'` |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | |
 
 ## Install
 

--- a/packages/remark-lint-code-block-style/readme.md
+++ b/packages/remark-lint-code-block-style/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'fenced'` |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | [`settings.fences`](https://github.com/remarkjs/remark-lint#configure) is `true` |
 
 ## Install
 
@@ -124,7 +124,7 @@ The default export is `remarkLintCodeBlockStyle`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: [`settings.fences`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences) or `'consistent'`) are accepted:
+The following options (default: [`settings.fences`](https://github.com/remarkjs/remark-lint#configure) or `'consistent'`) are accepted:
 
 *   `'fenced'`
     — prefer fenced code blocks:
@@ -156,15 +156,15 @@ Due to this, it’s recommended to configure this rule with `'fenced'`.
 [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
 formats code blocks as fenced code when they have a language flag and as
 indented code otherwise.
-Pass
-[`fences: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences)
+Change
+[`settings.fences`](https://github.com/remarkjs/remark-lint#configure) to `true`
 to always use fenced code.
 
 ## Examples
 
 ##### `ok.md`
 
-When configured with `'indented'`.
+When [`settings.fences`](https://github.com/remarkjs/remark-lint#configure) is `false` and the rule is not configured.
 
 ###### In
 
@@ -182,7 +182,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'indented'`.
+When [`settings.fences`](https://github.com/remarkjs/remark-lint#configure) is `false` and the rule is not configured.
 
 ###### In
 
@@ -207,50 +207,7 @@ bravo()
 
 ##### `ok.md`
 
-When [`settings.fences`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences) is `false` and the rule is not configured.
-
-###### In
-
-```markdown
-    alpha()
-
-Paragraph.
-
-    bravo()
-```
-
-###### Out
-
-No messages.
-
-##### `not-ok.md`
-
-When [`settings.fences`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences) is `false` and the rule is not configured.
-
-###### In
-
-````markdown
-```
-alpha()
-```
-
-Paragraph.
-
-```
-bravo()
-```
-````
-
-###### Out
-
-```text
-1:1-3:4: Code blocks should be indented
-7:1-9:4: Code blocks should be indented
-```
-
-##### `ok.md`
-
-When configured with `'fenced'`.
+When [`settings.fences`](https://github.com/remarkjs/remark-lint#configure) is `true` and the rule is not configured.
 
 ###### In
 
@@ -272,50 +229,7 @@ No messages.
 
 ##### `not-ok-fenced.md`
 
-When configured with `'fenced'`.
-
-###### In
-
-```markdown
-    alpha()
-
-Paragraph.
-
-    bravo()
-```
-
-###### Out
-
-```text
-1:1-1:12: Code blocks should be fenced
-5:1-5:12: Code blocks should be fenced
-```
-
-##### `ok.md`
-
-When [`settings.fences`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences) is `true` and the rule is not configured.
-
-###### In
-
-````markdown
-```
-alpha()
-```
-
-Paragraph.
-
-```
-bravo()
-```
-````
-
-###### Out
-
-No messages.
-
-##### `not-ok-fenced.md`
-
-When [`settings.fences`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences) is `true` and the rule is not configured.
+When [`settings.fences`](https://github.com/remarkjs/remark-lint#configure) is `true` and the rule is not configured.
 
 ###### In
 

--- a/packages/remark-lint-code-block-style/readme.md
+++ b/packages/remark-lint-code-block-style/readme.md
@@ -124,7 +124,7 @@ The default export is `remarkLintCodeBlockStyle`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: `'consistent'`) are accepted:
+The following options (default: [`settings.fences`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences) or `'consistent'`) are accepted:
 
 *   `'fenced'`
     — prefer fenced code blocks:
@@ -164,7 +164,7 @@ to always use fenced code.
 
 ##### `ok.md`
 
-When configured with `'indented'`.
+When configured with [`settings.fences: false`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences).
 
 ###### In
 
@@ -182,7 +182,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'indented'`.
+When configured with [`settings.fences: false`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences).
 
 ###### In
 
@@ -207,7 +207,7 @@ bravo()
 
 ##### `ok.md`
 
-When configured with `'fenced'`.
+When configured with [`settings.fences: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences).
 
 ###### In
 
@@ -229,7 +229,7 @@ No messages.
 
 ##### `not-ok-fenced.md`
 
-When configured with `'fenced'`.
+When configured with [`settings.fences: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences).
 
 ###### In
 

--- a/packages/remark-lint-emphasis-marker/index.js
+++ b/packages/remark-lint-emphasis-marker/index.js
@@ -141,8 +141,9 @@ const remarkLintEmphasisMarker = lintRule(
     const value = String(file)
 
     if (!option) {
-      const {settings} = this.data()
-      option = (settings && settings.emphasis) || 'consistent'
+      /** @type {import('remark-stringify').Options} */
+      const settings = this.data().settings || {}
+      option = settings.emphasis || 'consistent'
     }
 
     if (option !== '*' && option !== '_' && option !== 'consistent') {

--- a/packages/remark-lint-emphasis-marker/index.js
+++ b/packages/remark-lint-emphasis-marker/index.js
@@ -40,32 +40,32 @@
  * @copyright 2015 Titus Wormer
  * @license MIT
  * @example
- *   {"config": "*", "name": "ok.md"}
+ *   {"settings": {"emphasis": "*"}, "name": "ok.md"}
  *
  *   *foo*
  *
  * @example
- *   {"config": "*", "name": "not-ok.md", "label": "input"}
+ *   {"settings": {"emphasis": "*"}, "name": "not-ok.md", "label": "input"}
  *
  *   _foo_
  *
  * @example
- *   {"config": "*", "name": "not-ok.md", "label": "output"}
+ *   {"settings": {"emphasis": "*"}, "name": "not-ok.md", "label": "output"}
  *
  *   1:1-1:6: Emphasis should use `*` as a marker
  *
  * @example
- *   {"config": "_", "name": "ok.md"}
+ *   {"settings": {"emphasis": "_"}, "name": "ok.md"}
  *
  *   _foo_
  *
  * @example
- *   {"config": "_", "name": "not-ok.md", "label": "input"}
+ *   {"settings": {"emphasis": "_"}, "name": "not-ok.md", "label": "input"}
  *
  *   *foo*
  *
  * @example
- *   {"config": "_", "name": "not-ok.md", "label": "output"}
+ *   {"settings": {"emphasis": "_"}, "name": "not-ok.md", "label": "output"}
  *
  *   1:1-1:6: Emphasis should use `_` as a marker
  *
@@ -81,7 +81,7 @@
  *   2:1-2:6: Emphasis should use `*` as a marker
  *
  * @example
- *   {"config": "💩", "name": "not-ok.md", "label": "output", "positionless": true}
+ *   {"settings": {"emphasis": "💩"}, "name": "not-ok.md", "label": "output", "positionless": true}
  *
  *   1:1: Incorrect emphasis marker `💩`: use either `'consistent'`, `'*'`, or `'_'`
  */

--- a/packages/remark-lint-emphasis-marker/index.js
+++ b/packages/remark-lint-emphasis-marker/index.js
@@ -40,9 +40,24 @@
  * @copyright 2015 Titus Wormer
  * @license MIT
  * @example
+ *   {"config": "*", "name": "ok.md"}
+ *
+ *   *foo*
+ *
+ * @example
  *   {"settings": {"emphasis": "*"}, "name": "ok.md"}
  *
  *   *foo*
+ *
+ * @example
+ *   {"config": "*", "name": "not-ok.md", "label": "input"}
+ *
+ *   _foo_
+ *
+ * @example
+ *   {"config": "*", "name": "not-ok.md", "label": "output"}
+ *
+ *   1:1-1:6: Emphasis should use `*` as a marker
  *
  * @example
  *   {"settings": {"emphasis": "*"}, "name": "not-ok.md", "label": "input"}
@@ -55,9 +70,24 @@
  *   1:1-1:6: Emphasis should use `*` as a marker
  *
  * @example
+ *   {"config": "_", "name": "ok.md"}
+ *
+ *   _foo_
+ *
+ * @example
  *   {"settings": {"emphasis": "_"}, "name": "ok.md"}
  *
  *   _foo_
+ *
+ * @example
+ *   {"config": "_", "name": "not-ok.md", "label": "input"}
+ *
+ *   *foo*
+ *
+ * @example
+ *   {"config": "_", "name": "not-ok.md", "label": "output"}
+ *
+ *   1:1-1:6: Emphasis should use `_` as a marker
  *
  * @example
  *   {"settings": {"emphasis": "_"}, "name": "not-ok.md", "label": "input"}
@@ -79,6 +109,11 @@
  *   {"name": "not-ok.md", "label": "output"}
  *
  *   2:1-2:6: Emphasis should use `*` as a marker
+ *
+ * @example
+ *   {"config": "💩", "name": "not-ok.md", "label": "output", "positionless": true}
+ *
+ *   1:1: Incorrect emphasis marker `💩`: use either `'consistent'`, `'*'`, or `'_'`
  *
  * @example
  *   {"settings": {"emphasis": "💩"}, "name": "not-ok.md", "label": "output", "positionless": true}

--- a/packages/remark-lint-emphasis-marker/index.js
+++ b/packages/remark-lint-emphasis-marker/index.js
@@ -5,7 +5,7 @@
  *
  * ## API
  *
- * The following options (default: [`settings.emphasis`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis) or `'consistent'`) are accepted:
+ * The following options (default: [`settings.emphasis`](https://github.com/remarkjs/remark-lint#configure) or `'consistent'`) are accepted:
  *
  * *   `'*'`
  *     — prefer asterisks
@@ -29,8 +29,8 @@
  *
  * [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
  * formats emphasis with asterisks by default.
- * Pass
- * [`emphasis: '_'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis)
+ * Change
+ * [`settings.emphasis`](https://github.com/remarkjs/remark-lint#configure) to `'_'`
  * to always use underscores.
  *
  * @module emphasis-marker

--- a/packages/remark-lint-emphasis-marker/index.js
+++ b/packages/remark-lint-emphasis-marker/index.js
@@ -102,8 +102,13 @@ const remarkLintEmphasisMarker = lintRule(
     url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-emphasis-marker#readme'
   },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
-  (tree, file, option = 'consistent') => {
+  function (tree, file, option) {
     const value = String(file)
+
+    if (!option) {
+      const {settings} = this.data()
+      option = (settings && settings.emphasis) || 'consistent'
+    }
 
     if (option !== '*' && option !== '_' && option !== 'consistent') {
       file.fail(

--- a/packages/remark-lint-emphasis-marker/index.js
+++ b/packages/remark-lint-emphasis-marker/index.js
@@ -5,7 +5,7 @@
  *
  * ## API
  *
- * The following options (default: `'consistent'`) are accepted:
+ * The following options (default: [`settings.emphasis`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis) or `'consistent'`) are accepted:
  *
  * *   `'*'`
  *     — prefer asterisks

--- a/packages/remark-lint-emphasis-marker/readme.md
+++ b/packages/remark-lint-emphasis-marker/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'*'` |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | |
 
 ## Install
 

--- a/packages/remark-lint-emphasis-marker/readme.md
+++ b/packages/remark-lint-emphasis-marker/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'*'` |
 
 ## Install
 

--- a/packages/remark-lint-emphasis-marker/readme.md
+++ b/packages/remark-lint-emphasis-marker/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'*'` |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | [`settings.emphasis`](https://github.com/remarkjs/remark-lint#configure) is `'*'` |
 
 ## Install
 
@@ -124,7 +124,7 @@ The default export is `remarkLintEmphasisMarker`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: [`settings.emphasis`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis) or `'consistent'`) are accepted:
+The following options (default: [`settings.emphasis`](https://github.com/remarkjs/remark-lint#configure) or `'consistent'`) are accepted:
 
 *   `'*'`
     — prefer asterisks
@@ -148,15 +148,15 @@ can be used for more constructs, it’s recommended to prefer asterisks.
 
 [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
 formats emphasis with asterisks by default.
-Pass
-[`emphasis: '_'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis)
+Change
+[`settings.emphasis`](https://github.com/remarkjs/remark-lint#configure) to `'_'`
 to always use underscores.
 
 ## Examples
 
 ##### `ok.md`
 
-When configured with `'*'`.
+When [`settings.emphasis`](https://github.com/remarkjs/remark-lint#configure) is `'*'` and the rule is not configured.
 
 ###### In
 
@@ -170,7 +170,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'*'`.
+When [`settings.emphasis`](https://github.com/remarkjs/remark-lint#configure) is `'*'` and the rule is not configured.
 
 ###### In
 
@@ -186,37 +186,7 @@ _foo_
 
 ##### `ok.md`
 
-When [`settings.emphasis`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis) is `'*'` and the rule is not configured.
-
-###### In
-
-```markdown
-*foo*
-```
-
-###### Out
-
-No messages.
-
-##### `not-ok.md`
-
-When [`settings.emphasis`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis) is `'*'` and the rule is not configured.
-
-###### In
-
-```markdown
-_foo_
-```
-
-###### Out
-
-```text
-1:1-1:6: Emphasis should use `*` as a marker
-```
-
-##### `ok.md`
-
-When configured with `'_'`.
+When [`settings.emphasis`](https://github.com/remarkjs/remark-lint#configure) is `'_'` and the rule is not configured.
 
 ###### In
 
@@ -230,37 +200,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'_'`.
-
-###### In
-
-```markdown
-*foo*
-```
-
-###### Out
-
-```text
-1:1-1:6: Emphasis should use `_` as a marker
-```
-
-##### `ok.md`
-
-When [`settings.emphasis`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis) is `'_'` and the rule is not configured.
-
-###### In
-
-```markdown
-_foo_
-```
-
-###### Out
-
-No messages.
-
-##### `not-ok.md`
-
-When [`settings.emphasis`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis) is `'_'` and the rule is not configured.
+When [`settings.emphasis`](https://github.com/remarkjs/remark-lint#configure) is `'_'` and the rule is not configured.
 
 ###### In
 
@@ -291,17 +231,7 @@ _bar_
 
 ##### `not-ok.md`
 
-When configured with `'💩'`.
-
-###### Out
-
-```text
-1:1: Incorrect emphasis marker `💩`: use either `'consistent'`, `'*'`, or `'_'`
-```
-
-##### `not-ok.md`
-
-When [`settings.emphasis`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis) is `'💩'` and the rule is not configured.
+When [`settings.emphasis`](https://github.com/remarkjs/remark-lint#configure) is `'💩'` and the rule is not configured.
 
 ###### Out
 

--- a/packages/remark-lint-emphasis-marker/readme.md
+++ b/packages/remark-lint-emphasis-marker/readme.md
@@ -124,7 +124,7 @@ The default export is `remarkLintEmphasisMarker`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: `'consistent'`) are accepted:
+The following options (default: [`settings.emphasis`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis) or `'consistent'`) are accepted:
 
 *   `'*'`
     — prefer asterisks

--- a/packages/remark-lint-emphasis-marker/readme.md
+++ b/packages/remark-lint-emphasis-marker/readme.md
@@ -186,7 +186,7 @@ _foo_
 
 ##### `ok.md`
 
-When configured with [`settings.emphasis: '*'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis).
+When [`settings.emphasis`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis) is `'*'` and the rule is not configured.
 
 ###### In
 
@@ -200,7 +200,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with [`settings.emphasis: '*'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis).
+When [`settings.emphasis`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis) is `'*'` and the rule is not configured.
 
 ###### In
 
@@ -246,7 +246,7 @@ When configured with `'_'`.
 
 ##### `ok.md`
 
-When configured with [`settings.emphasis: '_'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis).
+When [`settings.emphasis`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis) is `'_'` and the rule is not configured.
 
 ###### In
 
@@ -260,7 +260,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with [`settings.emphasis: '_'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis).
+When [`settings.emphasis`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis) is `'_'` and the rule is not configured.
 
 ###### In
 
@@ -301,7 +301,7 @@ When configured with `'💩'`.
 
 ##### `not-ok.md`
 
-When configured with [`settings.emphasis: '💩'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis).
+When [`settings.emphasis`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis) is `'💩'` and the rule is not configured.
 
 ###### Out
 

--- a/packages/remark-lint-emphasis-marker/readme.md
+++ b/packages/remark-lint-emphasis-marker/readme.md
@@ -156,6 +156,36 @@ to always use underscores.
 
 ##### `ok.md`
 
+When configured with `'*'`.
+
+###### In
+
+```markdown
+*foo*
+```
+
+###### Out
+
+No messages.
+
+##### `not-ok.md`
+
+When configured with `'*'`.
+
+###### In
+
+```markdown
+_foo_
+```
+
+###### Out
+
+```text
+1:1-1:6: Emphasis should use `*` as a marker
+```
+
+##### `ok.md`
+
 When configured with [`settings.emphasis: '*'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis).
 
 ###### In
@@ -182,6 +212,36 @@ _foo_
 
 ```text
 1:1-1:6: Emphasis should use `*` as a marker
+```
+
+##### `ok.md`
+
+When configured with `'_'`.
+
+###### In
+
+```markdown
+_foo_
+```
+
+###### Out
+
+No messages.
+
+##### `not-ok.md`
+
+When configured with `'_'`.
+
+###### In
+
+```markdown
+*foo*
+```
+
+###### Out
+
+```text
+1:1-1:6: Emphasis should use `_` as a marker
 ```
 
 ##### `ok.md`
@@ -227,6 +287,16 @@ _bar_
 
 ```text
 2:1-2:6: Emphasis should use `*` as a marker
+```
+
+##### `not-ok.md`
+
+When configured with `'💩'`.
+
+###### Out
+
+```text
+1:1: Incorrect emphasis marker `💩`: use either `'consistent'`, `'*'`, or `'_'`
 ```
 
 ##### `not-ok.md`

--- a/packages/remark-lint-emphasis-marker/readme.md
+++ b/packages/remark-lint-emphasis-marker/readme.md
@@ -156,7 +156,7 @@ to always use underscores.
 
 ##### `ok.md`
 
-When configured with `'*'`.
+When configured with [`settings.emphasis: '*'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis).
 
 ###### In
 
@@ -170,7 +170,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'*'`.
+When configured with [`settings.emphasis: '*'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis).
 
 ###### In
 
@@ -186,7 +186,7 @@ _foo_
 
 ##### `ok.md`
 
-When configured with `'_'`.
+When configured with [`settings.emphasis: '_'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis).
 
 ###### In
 
@@ -200,7 +200,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'_'`.
+When configured with [`settings.emphasis: '_'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis).
 
 ###### In
 
@@ -231,7 +231,7 @@ _bar_
 
 ##### `not-ok.md`
 
-When configured with `'💩'`.
+When configured with [`settings.emphasis: '💩'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis).
 
 ###### Out
 

--- a/packages/remark-lint-fenced-code-flag/readme.md
+++ b/packages/remark-lint-fenced-code-flag/readme.md
@@ -208,22 +208,6 @@ alpha()
 
 ##### `ok.md`
 
-When configured with `[ 'alpha' ]`.
-
-###### In
-
-````markdown
-```alpha
-bravo()
-```
-````
-
-###### Out
-
-No messages.
-
-##### `ok.md`
-
 When configured with `{ flags: [ 'alpha' ] }`.
 
 ###### In

--- a/packages/remark-lint-fenced-code-marker/index.js
+++ b/packages/remark-lint-fenced-code-marker/index.js
@@ -5,7 +5,7 @@
  *
  * ## API
  *
- * The following options (default: [`settings.fence`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfence) or `'consistent'`) are accepted:
+ * The following options (default: [`settings.fence`](https://github.com/remarkjs/remark-lint#configure) or `'consistent'`) are accepted:
  *
  * *   ``'`'``
  *     — prefer grave accents
@@ -23,8 +23,8 @@
  *
  * [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
  * formats fenced code with grave accents by default.
- * Pass
- * [`fence: '~'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfence)
+ * Change
+ * [`settings.fence`](https://github.com/remarkjs/remark-lint#configure) to `'~'`
  * to always use tildes.
  *
  * @module fenced-code-marker

--- a/packages/remark-lint-fenced-code-marker/index.js
+++ b/packages/remark-lint-fenced-code-marker/index.js
@@ -147,8 +147,9 @@ const remarkLintFencedCodeMarker = lintRule(
     const contents = String(file)
 
     if (!option) {
-      const {settings} = this.data()
-      option = (settings && settings.fence) || 'consistent'
+      /** @type {import('remark-stringify').Options} */
+      const settings = this.data().settings || {}
+      option = settings.fence || 'consistent'
     }
 
     if (option !== 'consistent' && option !== '~' && option !== '`') {

--- a/packages/remark-lint-fenced-code-marker/index.js
+++ b/packages/remark-lint-fenced-code-marker/index.js
@@ -5,7 +5,7 @@
  *
  * ## API
  *
- * The following options (default: `'consistent'`) are accepted:
+ * The following options (default: [`settings.fence`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfence) or `'consistent'`) are accepted:
  *
  * *   ``'`'``
  *     — prefer grave accents
@@ -41,7 +41,7 @@
  *       bravo()
  *
  * @example
- *   {"name": "ok.md", "config": "`"}
+ *   {"name": "ok.md", "settings": {"fence": "`"}}
  *
  *   ```alpha
  *   bravo()
@@ -52,7 +52,7 @@
  *   ```
  *
  * @example
- *   {"name": "ok.md", "config": "~"}
+ *   {"name": "ok.md", "settings": {"fence": "~"}}
  *
  *   ~~~alpha
  *   bravo()
@@ -95,7 +95,7 @@
  *   5:1-7:4: Fenced code should use `~` as a marker
  *
  * @example
- *   {"name": "not-ok-incorrect.md", "config": "💩", "label": "output", "positionless": true}
+ *   {"name": "not-ok-incorrect.md", "settings": {"fence": "💩"}, "label": "output", "positionless": true}
  *
  *   1:1: Incorrect fenced code marker `💩`: use either `'consistent'`, `` '`' ``, or `'~'`
  */
@@ -116,8 +116,13 @@ const remarkLintFencedCodeMarker = lintRule(
     url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-fenced-code-marker#readme'
   },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
-  (tree, file, option = 'consistent') => {
+  function (tree, file, option) {
     const contents = String(file)
+
+    if (!option) {
+      const {settings} = this.data()
+      option = (settings && settings.fence) || 'consistent'
+    }
 
     if (option !== 'consistent' && option !== '~' && option !== '`') {
       file.fail(

--- a/packages/remark-lint-fenced-code-marker/index.js
+++ b/packages/remark-lint-fenced-code-marker/index.js
@@ -41,6 +41,17 @@
  *       bravo()
  *
  * @example
+ *   {"name": "ok.md", "config": "`"}
+ *
+ *   ```alpha
+ *   bravo()
+ *   ```
+ *
+ *   ```
+ *   charlie()
+ *   ```
+ *
+ * @example
  *   {"name": "ok.md", "settings": {"fence": "`"}}
  *
  *   ```alpha
@@ -50,6 +61,17 @@
  *   ```
  *   charlie()
  *   ```
+ *
+ * @example
+ *   {"name": "ok.md", "config": "~"}
+ *
+ *   ~~~alpha
+ *   bravo()
+ *   ~~~
+ *
+ *   ~~~
+ *   charlie()
+ *   ~~~
  *
  * @example
  *   {"name": "ok.md", "settings": {"fence": "~"}}
@@ -93,6 +115,11 @@
  *   {"name": "not-ok-consistent-tilde.md", "label": "output"}
  *
  *   5:1-7:4: Fenced code should use `~` as a marker
+ *
+ * @example
+ *   {"name": "not-ok-incorrect.md", "config": "💩", "label": "output", "positionless": true}
+ *
+ *   1:1: Incorrect fenced code marker `💩`: use either `'consistent'`, `` '`' ``, or `'~'`
  *
  * @example
  *   {"name": "not-ok-incorrect.md", "settings": {"fence": "💩"}, "label": "output", "positionless": true}

--- a/packages/remark-lint-fenced-code-marker/readme.md
+++ b/packages/remark-lint-fenced-code-marker/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | ``'`'`` |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | |
 
 ## Install
 

--- a/packages/remark-lint-fenced-code-marker/readme.md
+++ b/packages/remark-lint-fenced-code-marker/readme.md
@@ -224,7 +224,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with [``settings.fence: '`'``](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfence).
+When [`settings.fence`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfence) is ``'`'`` and the rule is not configured.
 
 ###### In
 
@@ -264,7 +264,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with [`settings.fence: '~'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfence).
+When [`settings.fence`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfence) is `'~'` and the rule is not configured.
 
 ###### In
 
@@ -294,7 +294,7 @@ When configured with `'💩'`.
 
 ##### `not-ok-incorrect.md`
 
-When configured with [`settings.fence: '💩'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfence).
+When [`settings.fence`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfence) is `'💩'` and the rule is not configured.
 
 ###### Out
 

--- a/packages/remark-lint-fenced-code-marker/readme.md
+++ b/packages/remark-lint-fenced-code-marker/readme.md
@@ -204,6 +204,26 @@ charlie()
 
 ##### `ok.md`
 
+When configured with ``'`'``.
+
+###### In
+
+````markdown
+```alpha
+bravo()
+```
+
+```
+charlie()
+```
+````
+
+###### Out
+
+No messages.
+
+##### `ok.md`
+
 When configured with [``settings.fence: '`'``](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfence).
 
 ###### In
@@ -217,6 +237,26 @@ bravo()
 charlie()
 ```
 ````
+
+###### Out
+
+No messages.
+
+##### `ok.md`
+
+When configured with `'~'`.
+
+###### In
+
+```markdown
+~~~alpha
+bravo()
+~~~
+
+~~~
+charlie()
+~~~
+```
 
 ###### Out
 
@@ -241,6 +281,16 @@ charlie()
 ###### Out
 
 No messages.
+
+##### `not-ok-incorrect.md`
+
+When configured with `'💩'`.
+
+###### Out
+
+```text
+1:1: Incorrect fenced code marker `💩`: use either `'consistent'`, `` '`' ``, or `'~'`
+```
 
 ##### `not-ok-incorrect.md`
 

--- a/packages/remark-lint-fenced-code-marker/readme.md
+++ b/packages/remark-lint-fenced-code-marker/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | ``'`'`` |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | [`settings.fence`](https://github.com/remarkjs/remark-lint#configure) is ``'`'`` |
 
 ## Install
 
@@ -124,7 +124,7 @@ The default export is `remarkLintFencedCodeMarker`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: [`settings.fence`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfence) or `'consistent'`) are accepted:
+The following options (default: [`settings.fence`](https://github.com/remarkjs/remark-lint#configure) or `'consistent'`) are accepted:
 
 *   ``'`'``
     — prefer grave accents
@@ -142,8 +142,8 @@ Due to this, it’s recommended to configure this rule with ``'`'``.
 
 [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
 formats fenced code with grave accents by default.
-Pass
-[`fence: '~'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfence)
+Change
+[`settings.fence`](https://github.com/remarkjs/remark-lint#configure) to `'~'`
 to always use tildes.
 
 ## Examples
@@ -204,7 +204,7 @@ charlie()
 
 ##### `ok.md`
 
-When configured with ``'`'``.
+When [`settings.fence`](https://github.com/remarkjs/remark-lint#configure) is ``'`'`` and the rule is not configured.
 
 ###### In
 
@@ -224,47 +224,7 @@ No messages.
 
 ##### `ok.md`
 
-When [`settings.fence`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfence) is ``'`'`` and the rule is not configured.
-
-###### In
-
-````markdown
-```alpha
-bravo()
-```
-
-```
-charlie()
-```
-````
-
-###### Out
-
-No messages.
-
-##### `ok.md`
-
-When configured with `'~'`.
-
-###### In
-
-```markdown
-~~~alpha
-bravo()
-~~~
-
-~~~
-charlie()
-~~~
-```
-
-###### Out
-
-No messages.
-
-##### `ok.md`
-
-When [`settings.fence`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfence) is `'~'` and the rule is not configured.
+When [`settings.fence`](https://github.com/remarkjs/remark-lint#configure) is `'~'` and the rule is not configured.
 
 ###### In
 
@@ -284,17 +244,7 @@ No messages.
 
 ##### `not-ok-incorrect.md`
 
-When configured with `'💩'`.
-
-###### Out
-
-```text
-1:1: Incorrect fenced code marker `💩`: use either `'consistent'`, `` '`' ``, or `'~'`
-```
-
-##### `not-ok-incorrect.md`
-
-When [`settings.fence`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfence) is `'💩'` and the rule is not configured.
+When [`settings.fence`](https://github.com/remarkjs/remark-lint#configure) is `'💩'` and the rule is not configured.
 
 ###### Out
 

--- a/packages/remark-lint-fenced-code-marker/readme.md
+++ b/packages/remark-lint-fenced-code-marker/readme.md
@@ -124,7 +124,7 @@ The default export is `remarkLintFencedCodeMarker`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: `'consistent'`) are accepted:
+The following options (default: [`settings.fence`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfence) or `'consistent'`) are accepted:
 
 *   ``'`'``
     — prefer grave accents
@@ -204,7 +204,7 @@ charlie()
 
 ##### `ok.md`
 
-When configured with ``'`'``.
+When configured with [``settings.fence: '`'``](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfence).
 
 ###### In
 
@@ -224,7 +224,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with `'~'`.
+When configured with [`settings.fence: '~'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfence).
 
 ###### In
 
@@ -244,7 +244,7 @@ No messages.
 
 ##### `not-ok-incorrect.md`
 
-When configured with `'💩'`.
+When configured with [`settings.fence: '💩'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfence).
 
 ###### Out
 

--- a/packages/remark-lint-fenced-code-marker/readme.md
+++ b/packages/remark-lint-fenced-code-marker/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | ``'`'`` |
 
 ## Install
 

--- a/packages/remark-lint-heading-style/index.js
+++ b/packages/remark-lint-heading-style/index.js
@@ -5,7 +5,7 @@
  *
  * ## API
  *
- * The following options (default: [`settings.setext`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionssetext), [`settings.closeAtx`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionscloseatx), or `'consistent'`) are accepted:
+ * The following options (default: [`settings.setext`](https://github.com/remarkjs/remark-lint#configure), [`settings.closeAtx`](https://github.com/remarkjs/remark-lint#configure), or `'consistent'`) are accepted:
  *
  * *   `'atx'`
  *     — prefer ATX headings:
@@ -51,9 +51,9 @@
  * [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
  * formats headings as ATX by default.
  * The other styles can be configured with
- * [`setext: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionssetext)
+ * [`settings.setext: true`](https://github.com/remarkjs/remark-lint#configure)
  * or
- * [`closeAtx: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionscloseatx).
+ * [`settings.closeAtx: true`](https://github.com/remarkjs/remark-lint#configure).
  *
  * @module heading-style
  * @summary

--- a/packages/remark-lint-heading-style/index.js
+++ b/packages/remark-lint-heading-style/index.js
@@ -5,7 +5,7 @@
  *
  * ## API
  *
- * The following options (default: `'consistent'`) are accepted:
+ * The following options (default: [`settings.setext`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionssetext), [`settings.closeAtx`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionscloseatx), or `'consistent'`) are accepted:
  *
  * *   `'atx'`
  *     — prefer ATX headings:
@@ -62,7 +62,7 @@
  * @copyright 2015 Titus Wormer
  * @license MIT
  * @example
- *   {"name": "ok.md", "config": "atx"}
+ *   {"name": "ok.md", "settings": {"setext": false}}
  *
  *   # Alpha
  *
@@ -71,7 +71,7 @@
  *   ### Charlie
  *
  * @example
- *   {"name": "ok.md", "config": "atx-closed"}
+ *   {"name": "ok.md", "settings": {"closeAtx": true}}
  *
  *   # Delta ##
  *
@@ -80,7 +80,7 @@
  *   ### Foxtrot ###
  *
  * @example
- *   {"name": "ok.md", "config": "setext"}
+ *   {"name": "ok.md", "settings": {"setext": true}}
  *
  *   Golf
  *   ====
@@ -129,7 +129,20 @@ const remarkLintHeadingStyle = lintRule(
     url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-heading-style#readme'
   },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
-  (tree, file, option = 'consistent') => {
+  function (tree, file, option) {
+    if (!option) {
+      const {settings} = this.data()
+      option =
+        !settings ||
+        (settings.setext === undefined && settings.closeAtx === undefined)
+          ? 'consistent'
+          : settings.setext
+          ? 'setext'
+          : settings.closeAtx
+          ? 'atx-closed'
+          : 'atx'
+    }
+
     if (
       option !== 'consistent' &&
       option !== 'atx' &&

--- a/packages/remark-lint-heading-style/index.js
+++ b/packages/remark-lint-heading-style/index.js
@@ -160,16 +160,16 @@ const remarkLintHeadingStyle = lintRule(
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
   function (tree, file, option) {
     if (!option) {
-      const {settings} = this.data()
+      /** @type {import('remark-stringify').Options} */
+      const settings = this.data().settings || {}
       option =
-        !settings ||
-        (settings.setext === undefined && settings.closeAtx === undefined)
-          ? 'consistent'
-          : settings.setext
+        settings.setext === true
           ? 'setext'
-          : settings.closeAtx
+          : settings.closeAtx === true
           ? 'atx-closed'
-          : 'atx'
+          : settings.setext === false || settings.closeAtx === false
+          ? 'atx'
+          : 'consistent'
     }
 
     if (

--- a/packages/remark-lint-heading-style/index.js
+++ b/packages/remark-lint-heading-style/index.js
@@ -62,6 +62,15 @@
  * @copyright 2015 Titus Wormer
  * @license MIT
  * @example
+ *   {"name": "ok.md", "config": "atx"}
+ *
+ *   # Alpha
+ *
+ *   ## Bravo
+ *
+ *   ### Charlie
+ *
+ * @example
  *   {"name": "ok.md", "settings": {"setext": false}}
  *
  *   # Alpha
@@ -71,6 +80,15 @@
  *   ### Charlie
  *
  * @example
+ *   {"name": "ok.md", "config": "atx-closed"}
+ *
+ *   # Delta ##
+ *
+ *   ## Echo ##
+ *
+ *   ### Foxtrot ###
+ *
+ * @example
  *   {"name": "ok.md", "settings": {"closeAtx": true}}
  *
  *   # Delta ##
@@ -78,6 +96,17 @@
  *   ## Echo ##
  *
  *   ### Foxtrot ###
+ *
+ * @example
+ *   {"name": "ok.md", "config": "setext"}
+ *
+ *   Golf
+ *   ====
+ *
+ *   Hotel
+ *   -----
+ *
+ *   ### India
  *
  * @example
  *   {"name": "ok.md", "settings": {"setext": true}}

--- a/packages/remark-lint-heading-style/readme.md
+++ b/packages/remark-lint-heading-style/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'atx'` |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | |
 
 ## Install
 

--- a/packages/remark-lint-heading-style/readme.md
+++ b/packages/remark-lint-heading-style/readme.md
@@ -178,6 +178,24 @@ or
 
 ##### `ok.md`
 
+When configured with `'atx'`.
+
+###### In
+
+```markdown
+# Alpha
+
+## Bravo
+
+### Charlie
+```
+
+###### Out
+
+No messages.
+
+##### `ok.md`
+
 When configured with [`settings.setext: false`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionssetext).
 
 ###### In
@@ -196,6 +214,24 @@ No messages.
 
 ##### `ok.md`
 
+When configured with `'atx-closed'`.
+
+###### In
+
+```markdown
+# Delta ##
+
+## Echo ##
+
+### Foxtrot ###
+```
+
+###### Out
+
+No messages.
+
+##### `ok.md`
+
 When configured with [`settings.closeAtx: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionscloseatx).
 
 ###### In
@@ -206,6 +242,26 @@ When configured with [`settings.closeAtx: true`](https://github.com/remarkjs/rem
 ## Echo ##
 
 ### Foxtrot ###
+```
+
+###### Out
+
+No messages.
+
+##### `ok.md`
+
+When configured with `'setext'`.
+
+###### In
+
+```markdown
+Golf
+====
+
+Hotel
+-----
+
+### India
 ```
 
 ###### Out

--- a/packages/remark-lint-heading-style/readme.md
+++ b/packages/remark-lint-heading-style/readme.md
@@ -124,7 +124,7 @@ The default export is `remarkLintHeadingStyle`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: `'consistent'`) are accepted:
+The following options (default: [`settings.setext`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionssetext), [`settings.closeAtx`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionscloseatx), or `'consistent'`) are accepted:
 
 *   `'atx'`
     — prefer ATX headings:
@@ -178,7 +178,7 @@ or
 
 ##### `ok.md`
 
-When configured with `'atx'`.
+When configured with [`settings.setext: false`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionssetext).
 
 ###### In
 
@@ -196,7 +196,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with `'atx-closed'`.
+When configured with [`settings.closeAtx: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionscloseatx).
 
 ###### In
 
@@ -214,7 +214,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with `'setext'`.
+When configured with [`settings.setext: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionssetext).
 
 ###### In
 

--- a/packages/remark-lint-heading-style/readme.md
+++ b/packages/remark-lint-heading-style/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'atx'` |
 
 ## Install
 

--- a/packages/remark-lint-heading-style/readme.md
+++ b/packages/remark-lint-heading-style/readme.md
@@ -196,7 +196,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with [`settings.setext: false`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionssetext).
+When [`settings.setext`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionssetext) is `false` and the rule is not configured.
 
 ###### In
 
@@ -232,7 +232,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with [`settings.closeAtx: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionscloseatx).
+When [`settings.closeAtx`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionscloseatx) is `true` and the rule is not configured.
 
 ###### In
 
@@ -270,7 +270,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with [`settings.setext: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionssetext).
+When [`settings.setext`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionssetext) is `true` and the rule is not configured.
 
 ###### In
 

--- a/packages/remark-lint-heading-style/readme.md
+++ b/packages/remark-lint-heading-style/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'atx'` |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | [`settings.setext`](https://github.com/remarkjs/remark-lint#configure) is `false` |
 
 ## Install
 
@@ -124,7 +124,7 @@ The default export is `remarkLintHeadingStyle`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: [`settings.setext`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionssetext), [`settings.closeAtx`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionscloseatx), or `'consistent'`) are accepted:
+The following options (default: [`settings.setext`](https://github.com/remarkjs/remark-lint#configure), [`settings.closeAtx`](https://github.com/remarkjs/remark-lint#configure), or `'consistent'`) are accepted:
 
 *   `'atx'`
     — prefer ATX headings:
@@ -170,15 +170,15 @@ Due to this, it’s recommended to prefer ATX headings.
 [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
 formats headings as ATX by default.
 The other styles can be configured with
-[`setext: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionssetext)
+[`settings.setext: true`](https://github.com/remarkjs/remark-lint#configure)
 or
-[`closeAtx: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionscloseatx).
+[`settings.closeAtx: true`](https://github.com/remarkjs/remark-lint#configure).
 
 ## Examples
 
 ##### `ok.md`
 
-When configured with `'atx'`.
+When [`settings.setext`](https://github.com/remarkjs/remark-lint#configure) is `false` and the rule is not configured.
 
 ###### In
 
@@ -196,25 +196,7 @@ No messages.
 
 ##### `ok.md`
 
-When [`settings.setext`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionssetext) is `false` and the rule is not configured.
-
-###### In
-
-```markdown
-# Alpha
-
-## Bravo
-
-### Charlie
-```
-
-###### Out
-
-No messages.
-
-##### `ok.md`
-
-When configured with `'atx-closed'`.
+When [`settings.closeAtx`](https://github.com/remarkjs/remark-lint#configure) is `true` and the rule is not configured.
 
 ###### In
 
@@ -232,45 +214,7 @@ No messages.
 
 ##### `ok.md`
 
-When [`settings.closeAtx`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionscloseatx) is `true` and the rule is not configured.
-
-###### In
-
-```markdown
-# Delta ##
-
-## Echo ##
-
-### Foxtrot ###
-```
-
-###### Out
-
-No messages.
-
-##### `ok.md`
-
-When configured with `'setext'`.
-
-###### In
-
-```markdown
-Golf
-====
-
-Hotel
------
-
-### India
-```
-
-###### Out
-
-No messages.
-
-##### `ok.md`
-
-When [`settings.setext`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionssetext) is `true` and the rule is not configured.
+When [`settings.setext`](https://github.com/remarkjs/remark-lint#configure) is `true` and the rule is not configured.
 
 ###### In
 

--- a/packages/remark-lint-link-title-style/index.js
+++ b/packages/remark-lint-link-title-style/index.js
@@ -5,7 +5,7 @@
  *
  * ## API
  *
- * The following options (default: `'consistent'`) are accepted:
+ * The following options (default: [`settings.quote`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote) or `'consistent'`) are accepted:
  *
  * *   `'"'`
  *     — prefer double quotes
@@ -44,7 +44,7 @@
  * @copyright 2015 Titus Wormer
  * @license MIT
  * @example
- *   {"name": "ok.md", "config": "\""}
+ *   {"name": "ok.md", "settings": {"quote": "\""}}
  *
  *   [Example](http://example.com#without-title)
  *   [Example](http://example.com "Example Domain")
@@ -57,17 +57,17 @@
  *   [Example](#Heading-(optional))
  *
  * @example
- *   {"name": "not-ok.md", "label": "input", "config": "\""}
+ *   {"name": "not-ok.md", "label": "input", "settings": {"quote": "\""}}
  *
  *   [Example]: http://example.com 'Example Domain'
  *
  * @example
- *   {"name": "not-ok.md", "label": "output", "config": "\""}
+ *   {"name": "not-ok.md", "label": "output", "settings": {"quote": "\""}}
  *
  *   1:31-1:47: Titles should use `"` as a quote
  *
  * @example
- *   {"name": "ok.md", "config": "'"}
+ *   {"name": "ok.md", "settings": {"quote": "'"}}
  *
  *   [Example](http://example.com#without-title)
  *   [Example](http://example.com 'Example Domain')
@@ -76,12 +76,12 @@
  *   [Example]: http://example.com 'Example Domain'
  *
  * @example
- *   {"name": "not-ok.md", "label": "input", "config": "'"}
+ *   {"name": "not-ok.md", "label": "input", "settings": {"quote": "'"}}
  *
  *   [Example]: http://example.com "Example Domain"
  *
  * @example
- *   {"name": "not-ok.md", "label": "output", "config": "'"}
+ *   {"name": "not-ok.md", "label": "output", "settings": {"quote": "'"}}
  *
  *   1:31-1:47: Titles should use `'` as a quote
  *
@@ -116,7 +116,7 @@
  *   2:30-2:46: Titles should use `"` as a quote
  *
  * @example
- *   {"name": "not-ok.md", "config": "💩", "label": "output", "positionless": true}
+ *   {"name": "not-ok.md", "settings": {"quote": "💩"}, "label": "output", "positionless": true}
  *
  *   1:1: Incorrect link title style marker `💩`: use either `'consistent'`, `'"'`, `'\''`, or `'()'`
  */
@@ -146,9 +146,15 @@ const remarkLintLinkTitleStyle = lintRule(
     url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-link-title-style#readme'
   },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
-  (tree, file, option = 'consistent') => {
+  function (tree, file, option) {
     const value = String(file)
     const loc = location(file)
+
+    if (!option) {
+      const {settings} = this.data()
+      option = (settings && settings.quote) || 'consistent'
+    }
+
     // @ts-expect-error: allow other paren combos.
     let look = option === '()' || option === '(' ? ')' : option
 

--- a/packages/remark-lint-link-title-style/index.js
+++ b/packages/remark-lint-link-title-style/index.js
@@ -198,8 +198,9 @@ const remarkLintLinkTitleStyle = lintRule(
     const loc = location(file)
 
     if (!option) {
-      const {settings} = this.data()
-      option = (settings && settings.quote) || 'consistent'
+      /** @type {import('remark-stringify').Options} */
+      const settings = this.data().settings || {}
+      option = settings.quote || 'consistent'
     }
 
     // @ts-expect-error: allow other paren combos.

--- a/packages/remark-lint-link-title-style/index.js
+++ b/packages/remark-lint-link-title-style/index.js
@@ -44,6 +44,19 @@
  * @copyright 2015 Titus Wormer
  * @license MIT
  * @example
+ *   {"name": "ok.md", "config": "\""}
+ *
+ *   [Example](http://example.com#without-title)
+ *   [Example](http://example.com "Example Domain")
+ *   ![Example](http://example.com "Example Domain")
+ *
+ *   [Example]: http://example.com "Example Domain"
+ *
+ *   You can use parens in URLs if they’re not a title (see GH-166):
+ *
+ *   [Example](#Heading-(optional))
+ *
+ * @example
  *   {"name": "ok.md", "settings": {"quote": "\""}}
  *
  *   [Example](http://example.com#without-title)
@@ -57,6 +70,16 @@
  *   [Example](#Heading-(optional))
  *
  * @example
+ *   {"name": "not-ok.md", "label": "input", "config": "\""}
+ *
+ *   [Example]: http://example.com 'Example Domain'
+ *
+ * @example
+ *   {"name": "not-ok.md", "label": "output", "config": "\""}
+ *
+ *   1:31-1:47: Titles should use `"` as a quote
+ *
+ * @example
  *   {"name": "not-ok.md", "label": "input", "settings": {"quote": "\""}}
  *
  *   [Example]: http://example.com 'Example Domain'
@@ -67,6 +90,15 @@
  *   1:31-1:47: Titles should use `"` as a quote
  *
  * @example
+ *   {"name": "ok.md", "config": "'"}
+ *
+ *   [Example](http://example.com#without-title)
+ *   [Example](http://example.com 'Example Domain')
+ *   ![Example](http://example.com 'Example Domain')
+ *
+ *   [Example]: http://example.com 'Example Domain'
+ *
+ * @example
  *   {"name": "ok.md", "settings": {"quote": "'"}}
  *
  *   [Example](http://example.com#without-title)
@@ -74,6 +106,16 @@
  *   ![Example](http://example.com 'Example Domain')
  *
  *   [Example]: http://example.com 'Example Domain'
+ *
+ * @example
+ *   {"name": "not-ok.md", "label": "input", "config": "'"}
+ *
+ *   [Example]: http://example.com "Example Domain"
+ *
+ * @example
+ *   {"name": "not-ok.md", "label": "output", "config": "'"}
+ *
+ *   1:31-1:47: Titles should use `'` as a quote
  *
  * @example
  *   {"name": "not-ok.md", "label": "input", "settings": {"quote": "'"}}
@@ -114,6 +156,11 @@
  *   {"name": "not-ok.md", "label": "output"}
  *
  *   2:30-2:46: Titles should use `"` as a quote
+ *
+ * @example
+ *   {"name": "not-ok.md", "config": "💩", "label": "output", "positionless": true}
+ *
+ *   1:1: Incorrect link title style marker `💩`: use either `'consistent'`, `'"'`, `'\''`, or `'()'`
  *
  * @example
  *   {"name": "not-ok.md", "settings": {"quote": "💩"}, "label": "output", "positionless": true}

--- a/packages/remark-lint-link-title-style/index.js
+++ b/packages/remark-lint-link-title-style/index.js
@@ -5,7 +5,7 @@
  *
  * ## API
  *
- * The following options (default: [`settings.quote`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote) or `'consistent'`) are accepted:
+ * The following options (default: [`settings.quote`](https://github.com/remarkjs/remark-lint#configure) or `'consistent'`) are accepted:
  *
  * *   `'"'`
  *     — prefer double quotes
@@ -32,8 +32,8 @@
  *
  * [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
  * formats titles with double quotes by default.
- * Pass
- * [`quote: "'"`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote)
+ * Change
+ * [`settings.quote`](https://github.com/remarkjs/remark-lint#configure) to `"'"`
  * to use single quotes.
  * There is no option to use parens.
  *

--- a/packages/remark-lint-link-title-style/readme.md
+++ b/packages/remark-lint-link-title-style/readme.md
@@ -198,7 +198,7 @@ When configured with `'"'`.
 
 ##### `ok.md`
 
-When configured with [`settings.quote: '"'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote).
+When [`settings.quote`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote) is `'"'` and the rule is not configured.
 
 ###### In
 
@@ -220,7 +220,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with [`settings.quote: '"'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote).
+When [`settings.quote`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote) is `'"'` and the rule is not configured.
 
 ###### In
 
@@ -270,7 +270,7 @@ When configured with `"'"`.
 
 ##### `ok.md`
 
-When configured with [`settings.quote: "'"`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote).
+When [`settings.quote`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote) is `"'"` and the rule is not configured.
 
 ###### In
 
@@ -288,7 +288,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with [`settings.quote: "'"`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote).
+When [`settings.quote`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote) is `"'"` and the rule is not configured.
 
 ###### In
 
@@ -363,7 +363,7 @@ When configured with `'💩'`.
 
 ##### `not-ok.md`
 
-When configured with [`settings.quote: '💩'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote).
+When [`settings.quote`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote) is `'💩'` and the rule is not configured.
 
 ###### Out
 

--- a/packages/remark-lint-link-title-style/readme.md
+++ b/packages/remark-lint-link-title-style/readme.md
@@ -124,7 +124,7 @@ The default export is `remarkLintLinkTitleStyle`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: `'consistent'`) are accepted:
+The following options (default: [`settings.quote`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote) or `'consistent'`) are accepted:
 
 *   `'"'`
     — prefer double quotes
@@ -160,7 +160,7 @@ There is no option to use parens.
 
 ##### `ok.md`
 
-When configured with `'"'`.
+When configured with [`settings.quote: '"'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote).
 
 ###### In
 
@@ -182,7 +182,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'"'`.
+When configured with [`settings.quote: '"'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote).
 
 ###### In
 
@@ -198,7 +198,7 @@ When configured with `'"'`.
 
 ##### `ok.md`
 
-When configured with `"'"`.
+When configured with [`settings.quote: "'"`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote).
 
 ###### In
 
@@ -216,7 +216,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `"'"`.
+When configured with [`settings.quote: "'"`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote).
 
 ###### In
 
@@ -281,7 +281,7 @@ When configured with `'()'`.
 
 ##### `not-ok.md`
 
-When configured with `'💩'`.
+When configured with [`settings.quote: '💩'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote).
 
 ###### Out
 

--- a/packages/remark-lint-link-title-style/readme.md
+++ b/packages/remark-lint-link-title-style/readme.md
@@ -160,6 +160,44 @@ There is no option to use parens.
 
 ##### `ok.md`
 
+When configured with `'"'`.
+
+###### In
+
+```markdown
+[Example](http://example.com#without-title)
+[Example](http://example.com "Example Domain")
+![Example](http://example.com "Example Domain")
+
+[Example]: http://example.com "Example Domain"
+
+You can use parens in URLs if they’re not a title (see GH-166):
+
+[Example](#Heading-(optional))
+```
+
+###### Out
+
+No messages.
+
+##### `not-ok.md`
+
+When configured with `'"'`.
+
+###### In
+
+```markdown
+[Example]: http://example.com 'Example Domain'
+```
+
+###### Out
+
+```text
+1:31-1:47: Titles should use `"` as a quote
+```
+
+##### `ok.md`
+
 When configured with [`settings.quote: '"'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote).
 
 ###### In
@@ -194,6 +232,40 @@ When configured with [`settings.quote: '"'`](https://github.com/remarkjs/remark/
 
 ```text
 1:31-1:47: Titles should use `"` as a quote
+```
+
+##### `ok.md`
+
+When configured with `"'"`.
+
+###### In
+
+```markdown
+[Example](http://example.com#without-title)
+[Example](http://example.com 'Example Domain')
+![Example](http://example.com 'Example Domain')
+
+[Example]: http://example.com 'Example Domain'
+```
+
+###### Out
+
+No messages.
+
+##### `not-ok.md`
+
+When configured with `"'"`.
+
+###### In
+
+```markdown
+[Example]: http://example.com "Example Domain"
+```
+
+###### Out
+
+```text
+1:31-1:47: Titles should use `'` as a quote
 ```
 
 ##### `ok.md`
@@ -277,6 +349,16 @@ When configured with `'()'`.
 
 ```text
 2:30-2:46: Titles should use `"` as a quote
+```
+
+##### `not-ok.md`
+
+When configured with `'💩'`.
+
+###### Out
+
+```text
+1:1: Incorrect link title style marker `💩`: use either `'consistent'`, `'"'`, `'\''`, or `'()'`
 ```
 
 ##### `not-ok.md`

--- a/packages/remark-lint-link-title-style/readme.md
+++ b/packages/remark-lint-link-title-style/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'"'` |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | |
 
 ## Install
 

--- a/packages/remark-lint-link-title-style/readme.md
+++ b/packages/remark-lint-link-title-style/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'"'` |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | [`settings.quote`](https://github.com/remarkjs/remark-lint#configure) is `'"'` |
 
 ## Install
 
@@ -124,7 +124,7 @@ The default export is `remarkLintLinkTitleStyle`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: [`settings.quote`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote) or `'consistent'`) are accepted:
+The following options (default: [`settings.quote`](https://github.com/remarkjs/remark-lint#configure) or `'consistent'`) are accepted:
 
 *   `'"'`
     — prefer double quotes
@@ -151,8 +151,8 @@ markdown, so it’s recommended to configure this rule with `'"'`.
 
 [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
 formats titles with double quotes by default.
-Pass
-[`quote: "'"`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote)
+Change
+[`settings.quote`](https://github.com/remarkjs/remark-lint#configure) to `"'"`
 to use single quotes.
 There is no option to use parens.
 
@@ -160,7 +160,7 @@ There is no option to use parens.
 
 ##### `ok.md`
 
-When configured with `'"'`.
+When [`settings.quote`](https://github.com/remarkjs/remark-lint#configure) is `'"'` and the rule is not configured.
 
 ###### In
 
@@ -182,7 +182,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'"'`.
+When [`settings.quote`](https://github.com/remarkjs/remark-lint#configure) is `'"'` and the rule is not configured.
 
 ###### In
 
@@ -198,45 +198,7 @@ When configured with `'"'`.
 
 ##### `ok.md`
 
-When [`settings.quote`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote) is `'"'` and the rule is not configured.
-
-###### In
-
-```markdown
-[Example](http://example.com#without-title)
-[Example](http://example.com "Example Domain")
-![Example](http://example.com "Example Domain")
-
-[Example]: http://example.com "Example Domain"
-
-You can use parens in URLs if they’re not a title (see GH-166):
-
-[Example](#Heading-(optional))
-```
-
-###### Out
-
-No messages.
-
-##### `not-ok.md`
-
-When [`settings.quote`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote) is `'"'` and the rule is not configured.
-
-###### In
-
-```markdown
-[Example]: http://example.com 'Example Domain'
-```
-
-###### Out
-
-```text
-1:31-1:47: Titles should use `"` as a quote
-```
-
-##### `ok.md`
-
-When configured with `"'"`.
+When [`settings.quote`](https://github.com/remarkjs/remark-lint#configure) is `"'"` and the rule is not configured.
 
 ###### In
 
@@ -254,41 +216,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `"'"`.
-
-###### In
-
-```markdown
-[Example]: http://example.com "Example Domain"
-```
-
-###### Out
-
-```text
-1:31-1:47: Titles should use `'` as a quote
-```
-
-##### `ok.md`
-
-When [`settings.quote`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote) is `"'"` and the rule is not configured.
-
-###### In
-
-```markdown
-[Example](http://example.com#without-title)
-[Example](http://example.com 'Example Domain')
-![Example](http://example.com 'Example Domain')
-
-[Example]: http://example.com 'Example Domain'
-```
-
-###### Out
-
-No messages.
-
-##### `not-ok.md`
-
-When [`settings.quote`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote) is `"'"` and the rule is not configured.
+When [`settings.quote`](https://github.com/remarkjs/remark-lint#configure) is `"'"` and the rule is not configured.
 
 ###### In
 
@@ -353,17 +281,7 @@ When configured with `'()'`.
 
 ##### `not-ok.md`
 
-When configured with `'💩'`.
-
-###### Out
-
-```text
-1:1: Incorrect link title style marker `💩`: use either `'consistent'`, `'"'`, `'\''`, or `'()'`
-```
-
-##### `not-ok.md`
-
-When [`settings.quote`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote) is `'💩'` and the rule is not configured.
+When [`settings.quote`](https://github.com/remarkjs/remark-lint#configure) is `'💩'` and the rule is not configured.
 
 ###### Out
 

--- a/packages/remark-lint-link-title-style/readme.md
+++ b/packages/remark-lint-link-title-style/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'"'` |
 
 ## Install
 

--- a/packages/remark-lint-list-item-indent/index.js
+++ b/packages/remark-lint-list-item-indent/index.js
@@ -249,8 +249,9 @@ const remarkLintListItemIndent = lintRule(
         : option
 
     if (!option) {
-      const {settings} = this.data()
-      option = (settings && settings.listItemIndent) || 'tab'
+      /** @type {import('remark-stringify').Options} */
+      const settings = this.data().settings || {}
+      option = settings.listItemIndent || 'tab'
     }
 
     if (option !== 'tab' && option !== 'one' && option !== 'mixed') {

--- a/packages/remark-lint-list-item-indent/index.js
+++ b/packages/remark-lint-list-item-indent/index.js
@@ -79,6 +79,23 @@
  *   ····item.
  *
  * @example
+ *   {"name": "ok.md", "config": "mixed"}
+ *
+ *   *·List item.
+ *
+ *   Paragraph.
+ *
+ *   11.·List item
+ *
+ *   Paragraph.
+ *
+ *   *···List
+ *   ····item.
+ *
+ *   *···List
+ *   ····item.
+ *
+ * @example
  *   {"name": "ok.md", "settings": {"listItemIndent": "mixed"}}
  *
  *   *·List item.
@@ -94,6 +111,23 @@
  *
  *   *···List
  *   ····item.
+ *
+ * @example
+ *   {"name": "ok.md", "config": "one"}
+ *
+ *   *·List item.
+ *
+ *   Paragraph.
+ *
+ *   11.·List item
+ *
+ *   Paragraph.
+ *
+ *   *·List
+ *   ··item.
+ *
+ *   *·List
+ *   ··item.
  *
  * @example
  *   {"name": "ok.md", "settings": {"listItemIndent": "one"}}
@@ -113,6 +147,17 @@
  *   ··item.
  *
  * @example
+ *   {"name": "not-ok.md", "config": "one", "label": "input"}
+ *
+ *   *···List
+ *   ····item.
+ *
+ * @example
+ *   {"name": "not-ok.md", "config": "one", "label": "output"}
+ *
+ *    1:5: Incorrect list-item indent: remove 2 spaces
+ *
+ * @example
  *   {"name": "not-ok.md", "settings": {"listItemIndent": "one"}, "label": "input"}
  *
  *   *···List
@@ -122,6 +167,17 @@
  *   {"name": "not-ok.md", "settings": {"listItemIndent": "one"}, "label": "output"}
  *
  *    1:5: Incorrect list-item indent: remove 2 spaces
+ *
+ * @example
+ *   {"name": "not-ok.md", "config": "tab", "label": "input"}
+ *
+ *   *·List
+ *   ··item.
+ *
+ * @example
+ *   {"name": "not-ok.md", "config": "tab", "label": "output"}
+ *
+ *    1:3: Incorrect list-item indent: add 2 spaces
  *
  * @example
  *   {"name": "not-ok.md", "settings": {"listItemIndent": "tab"}, "label": "input"}
@@ -135,6 +191,16 @@
  *    1:3: Incorrect list-item indent: add 2 spaces
  *
  * @example
+ *   {"name": "not-ok.md", "config": "mixed", "label": "input"}
+ *
+ *   *···List item.
+ *
+ * @example
+ *   {"name": "not-ok.md", "config": "mixed", "label": "output"}
+ *
+ *    1:5: Incorrect list-item indent: remove 2 spaces
+ *
+ * @example
  *   {"name": "not-ok.md", "settings": {"listItemIndent": "mixed"}, "label": "input"}
  *
  *   *···List item.
@@ -143,6 +209,11 @@
  *   {"name": "not-ok.md", "settings": {"listItemIndent": "mixed"}, "label": "output"}
  *
  *    1:5: Incorrect list-item indent: remove 2 spaces
+ *
+ * @example
+ *   {"name": "not-ok.md", "config": "💩", "label": "output", "positionless": true}
+ *
+ *    1:1: Incorrect list-item indent style `💩`: use either `'tab'`, `'one'`, or `'mixed'`
  *
  * @example
  *   {"name": "not-ok.md", "settings": {"listItemIndent": "💩"}, "label": "output", "positionless": true}

--- a/packages/remark-lint-list-item-indent/index.js
+++ b/packages/remark-lint-list-item-indent/index.js
@@ -6,7 +6,7 @@
  *
  * ## API
  *
- * The following options (default: [`settings.listItemIndent`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent) or `'tab'`) are accepted:
+ * The following options (default: [`settings.listItemIndent`](https://github.com/remarkjs/remark-lint#configure) or `'tab'`) are accepted:
  *
  * *   `'one'`
  *     — prefer a single space
@@ -49,7 +49,7 @@
  *
  * [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
  * uses `'tab'` by default.
- * [`listItemIndent: 'one'` or `listItemIndent: 'mixed'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent)
+ * [`settings.listItemIndent: 'one'` or `settings.listItemIndent: 'mixed'`](https://github.com/remarkjs/remark-lint#configure)
  * is supported.
  *
  * @module list-item-indent

--- a/packages/remark-lint-list-item-indent/index.js
+++ b/packages/remark-lint-list-item-indent/index.js
@@ -6,7 +6,7 @@
  *
  * ## API
  *
- * The following options (default: `'tab'`) are accepted:
+ * The following options (default: [`settings.listItemIndent`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent) or `'tab'`) are accepted:
  *
  * *   `'one'`
  *     — prefer a single space
@@ -79,7 +79,7 @@
  *   ····item.
  *
  * @example
- *   {"name": "ok.md", "config": "mixed"}
+ *   {"name": "ok.md", "settings": {"listItemIndent": "mixed"}}
  *
  *   *·List item.
  *
@@ -96,7 +96,7 @@
  *   ····item.
  *
  * @example
- *   {"name": "ok.md", "config": "one"}
+ *   {"name": "ok.md", "settings": {"listItemIndent": "one"}}
  *
  *   *·List item.
  *
@@ -113,39 +113,39 @@
  *   ··item.
  *
  * @example
- *   {"name": "not-ok.md", "config": "one", "label": "input"}
+ *   {"name": "not-ok.md", "settings": {"listItemIndent": "one"}, "label": "input"}
  *
  *   *···List
  *   ····item.
  *
  * @example
- *   {"name": "not-ok.md", "config": "one", "label": "output"}
+ *   {"name": "not-ok.md", "settings": {"listItemIndent": "one"}, "label": "output"}
  *
  *    1:5: Incorrect list-item indent: remove 2 spaces
  *
  * @example
- *   {"name": "not-ok.md", "config": "tab", "label": "input"}
+ *   {"name": "not-ok.md", "settings": {"listItemIndent": "tab"}, "label": "input"}
  *
  *   *·List
  *   ··item.
  *
  * @example
- *   {"name": "not-ok.md", "config": "tab", "label": "output"}
+ *   {"name": "not-ok.md", "settings": {"listItemIndent": "tab"}, "label": "output"}
  *
  *    1:3: Incorrect list-item indent: add 2 spaces
  *
  * @example
- *   {"name": "not-ok.md", "config": "mixed", "label": "input"}
+ *   {"name": "not-ok.md", "settings": {"listItemIndent": "mixed"}, "label": "input"}
  *
  *   *···List item.
  *
  * @example
- *   {"name": "not-ok.md", "config": "mixed", "label": "output"}
+ *   {"name": "not-ok.md", "settings": {"listItemIndent": "mixed"}, "label": "output"}
  *
  *    1:5: Incorrect list-item indent: remove 2 spaces
  *
  * @example
- *   {"name": "not-ok.md", "config": "💩", "label": "output", "positionless": true}
+ *   {"name": "not-ok.md", "settings": {"listItemIndent": "💩"}, "label": "output", "positionless": true}
  *
  *    1:1: Incorrect list-item indent style `💩`: use either `'tab'`, `'one'`, or `'mixed'`
  */
@@ -167,7 +167,7 @@ const remarkLintListItemIndent = lintRule(
     url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent#readme'
   },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
-  (tree, file, option = 'tab') => {
+  function (tree, file, option) {
     const value = String(file)
     // TODO(next major): Remove legacy fallbacks.
     option =
@@ -176,6 +176,11 @@ const remarkLintListItemIndent = lintRule(
         : /** @type {unknown} */ (option) === 'space'
         ? /* c8 ignore next */ 'one'
         : option
+
+    if (!option) {
+      const {settings} = this.data()
+      option = (settings && settings.listItemIndent) || 'tab'
+    }
 
     if (option !== 'tab' && option !== 'one' && option !== 'mixed') {
       file.fail(

--- a/packages/remark-lint-list-item-indent/index.js
+++ b/packages/remark-lint-list-item-indent/index.js
@@ -6,14 +6,14 @@
  *
  * ## API
  *
- * The following options (default: `'tab-size'`) are accepted:
+ * The following options (default: `'tab'`) are accepted:
  *
- * *   `'space'`
+ * *   `'one'`
  *     — prefer a single space
- * *   `'tab-size'`
+ * *   `'tab'`
  *     — prefer spaces the size of the next tab stop
  * *   `'mixed'`
- *     — prefer `'space'` for tight lists and `'tab-size'` for loose lists
+ *     — prefer `'one'` for tight lists and `'tab'` for loose lists
  *
  * ## Recommendation
  *
@@ -39,17 +39,17 @@
  * especially with how they interact with indented code.
  * CommonMark made that a *lot* better, but there remain (documented but
  * complex) edge cases and some behavior intuitive.
- * Due to this, the default of this list is `'tab-size'`, which worked the best
+ * Due to this, the default of this list is `'tab'`, which worked the best
  * in most markdown parsers.
  * Currently, the situation between markdown parsers is better, so choosing
- * `'space'` (which seems to be the most common style used by authors) should
+ * `'one'` (which seems to be the most common style used by authors) should
  * be okay.
  *
  * ## Fix
  *
  * [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
- * uses `'tab-size'` (named `'tab'` there) by default.
- * [`listItemIndent: '1'` (for `'space'`) or `listItemIndent: 'mixed'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent)
+ * uses `'tab'` by default.
+ * [`listItemIndent: 'one'` or `listItemIndent: 'mixed'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent)
  * is supported.
  *
  * @module list-item-indent
@@ -96,7 +96,7 @@
  *   ····item.
  *
  * @example
- *   {"name": "ok.md", "config": "space"}
+ *   {"name": "ok.md", "config": "one"}
  *
  *   *·List item.
  *
@@ -113,24 +113,24 @@
  *   ··item.
  *
  * @example
- *   {"name": "not-ok.md", "config": "space", "label": "input"}
+ *   {"name": "not-ok.md", "config": "one", "label": "input"}
  *
  *   *···List
  *   ····item.
  *
  * @example
- *   {"name": "not-ok.md", "config": "space", "label": "output"}
+ *   {"name": "not-ok.md", "config": "one", "label": "output"}
  *
  *    1:5: Incorrect list-item indent: remove 2 spaces
  *
  * @example
- *   {"name": "not-ok.md", "config": "tab-size", "label": "input"}
+ *   {"name": "not-ok.md", "config": "tab", "label": "input"}
  *
  *   *·List
  *   ··item.
  *
  * @example
- *   {"name": "not-ok.md", "config": "tab-size", "label": "output"}
+ *   {"name": "not-ok.md", "config": "tab", "label": "output"}
  *
  *    1:3: Incorrect list-item indent: add 2 spaces
  *
@@ -147,12 +147,12 @@
  * @example
  *   {"name": "not-ok.md", "config": "💩", "label": "output", "positionless": true}
  *
- *    1:1: Incorrect list-item indent style `💩`: use either `'tab-size'`, `'space'`, or `'mixed'`
+ *    1:1: Incorrect list-item indent style `💩`: use either `'tab'`, `'one'`, or `'mixed'`
  */
 
 /**
  * @typedef {import('mdast').Root} Root
- * @typedef {'tab-size'|'space'|'mixed'} Options
+ * @typedef {'tab'|'one'|'mixed'} Options
  */
 
 import {lintRule} from 'unified-lint-rule'
@@ -167,14 +167,21 @@ const remarkLintListItemIndent = lintRule(
     url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent#readme'
   },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
-  (tree, file, option = 'tab-size') => {
+  (tree, file, option = 'tab') => {
     const value = String(file)
+    // TODO(next major): Remove legacy fallbacks.
+    option =
+      /** @type {unknown} */ (option) === 'tab-size'
+        ? /* c8 ignore next */ 'tab'
+        : /** @type {unknown} */ (option) === 'space'
+        ? /* c8 ignore next */ 'one'
+        : option
 
-    if (option !== 'tab-size' && option !== 'space' && option !== 'mixed') {
+    if (option !== 'tab' && option !== 'one' && option !== 'mixed') {
       file.fail(
         'Incorrect list-item indent style `' +
           option +
-          "`: use either `'tab-size'`, `'space'`, or `'mixed'`"
+          "`: use either `'tab'`, `'one'`, or `'mixed'`"
       )
     }
 
@@ -196,7 +203,7 @@ const remarkLintListItemIndent = lintRule(
         const bulletSize = marker.replace(/\s+$/, '').length
 
         const style =
-          option === 'tab-size' || (option === 'mixed' && spread)
+          option === 'tab' || (option === 'mixed' && spread)
             ? Math.ceil(bulletSize / 4) * 4
             : bulletSize + 1
 

--- a/packages/remark-lint-list-item-indent/readme.md
+++ b/packages/remark-lint-list-item-indent/readme.md
@@ -126,7 +126,7 @@ The default export is `remarkLintListItemIndent`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: `'tab'`) are accepted:
+The following options (default: [`settings.listItemIndent`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent) or `'tab'`) are accepted:
 
 *   `'one'`
     — prefer a single space
@@ -204,7 +204,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with `'mixed'`.
+When configured with [`settings.listItemIndent: 'mixed'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent).
 
 ###### In
 
@@ -232,7 +232,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'mixed'`.
+When configured with [`settings.listItemIndent: 'mixed'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent).
 
 ###### In
 
@@ -250,7 +250,7 @@ When configured with `'mixed'`.
 
 ##### `ok.md`
 
-When configured with `'one'`.
+When configured with [`settings.listItemIndent: 'one'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent).
 
 ###### In
 
@@ -278,7 +278,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'one'`.
+When configured with [`settings.listItemIndent: 'one'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent).
 
 ###### In
 
@@ -297,7 +297,7 @@ When configured with `'one'`.
 
 ##### `not-ok.md`
 
-When configured with `'tab'`.
+When configured with [`settings.listItemIndent: 'tab'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent).
 
 ###### In
 
@@ -316,7 +316,7 @@ When configured with `'tab'`.
 
 ##### `not-ok.md`
 
-When configured with `'💩'`.
+When configured with [`settings.listItemIndent: '💩'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent).
 
 ###### Out
 

--- a/packages/remark-lint-list-item-indent/readme.md
+++ b/packages/remark-lint-list-item-indent/readme.md
@@ -46,8 +46,8 @@ This rule is included in the following presets:
 
 | Preset | Setting |
 | - | - |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'mixed'` |
-| [`remark-preset-lint-recommended`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-recommended) | `'tab'` |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | [`settings.listItemIndent`](https://github.com/remarkjs/remark-lint#configure) is `'mixed'` |
+| [`remark-preset-lint-recommended`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-recommended) | [`settings.listItemIndent`](https://github.com/remarkjs/remark-lint#configure) is `'tab'` |
 
 ## Install
 
@@ -126,7 +126,7 @@ The default export is `remarkLintListItemIndent`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: [`settings.listItemIndent`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent) or `'tab'`) are accepted:
+The following options (default: [`settings.listItemIndent`](https://github.com/remarkjs/remark-lint#configure) or `'tab'`) are accepted:
 
 *   `'one'`
     — prefer a single space
@@ -169,7 +169,7 @@ be okay.
 
 [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
 uses `'tab'` by default.
-[`listItemIndent: 'one'` or `listItemIndent: 'mixed'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent)
+[`settings.listItemIndent: 'one'` or `settings.listItemIndent: 'mixed'`](https://github.com/remarkjs/remark-lint#configure)
 is supported.
 
 ## Examples
@@ -204,7 +204,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with `'mixed'`.
+When [`settings.listItemIndent`](https://github.com/remarkjs/remark-lint#configure) is `'mixed'` and the rule is not configured.
 
 ###### In
 
@@ -232,7 +232,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'mixed'`.
+When [`settings.listItemIndent`](https://github.com/remarkjs/remark-lint#configure) is `'mixed'` and the rule is not configured.
 
 ###### In
 
@@ -250,53 +250,7 @@ When configured with `'mixed'`.
 
 ##### `ok.md`
 
-When [`settings.listItemIndent`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent) is `'mixed'` and the rule is not configured.
-
-###### In
-
-> 👉 **Note**: `·` represents a space.
-
-```markdown
-*·List item.
-
-Paragraph.
-
-11.·List item
-
-Paragraph.
-
-*···List
-····item.
-
-*···List
-····item.
-```
-
-###### Out
-
-No messages.
-
-##### `not-ok.md`
-
-When [`settings.listItemIndent`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent) is `'mixed'` and the rule is not configured.
-
-###### In
-
-> 👉 **Note**: `·` represents a space.
-
-```markdown
-*···List item.
-```
-
-###### Out
-
-```text
-1:5: Incorrect list-item indent: remove 2 spaces
-```
-
-##### `ok.md`
-
-When configured with `'one'`.
+When [`settings.listItemIndent`](https://github.com/remarkjs/remark-lint#configure) is `'one'` and the rule is not configured.
 
 ###### In
 
@@ -324,54 +278,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'one'`.
-
-###### In
-
-> 👉 **Note**: `·` represents a space.
-
-```markdown
-*···List
-····item.
-```
-
-###### Out
-
-```text
-1:5: Incorrect list-item indent: remove 2 spaces
-```
-
-##### `ok.md`
-
-When [`settings.listItemIndent`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent) is `'one'` and the rule is not configured.
-
-###### In
-
-> 👉 **Note**: `·` represents a space.
-
-```markdown
-*·List item.
-
-Paragraph.
-
-11.·List item
-
-Paragraph.
-
-*·List
-··item.
-
-*·List
-··item.
-```
-
-###### Out
-
-No messages.
-
-##### `not-ok.md`
-
-When [`settings.listItemIndent`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent) is `'one'` and the rule is not configured.
+When [`settings.listItemIndent`](https://github.com/remarkjs/remark-lint#configure) is `'one'` and the rule is not configured.
 
 ###### In
 
@@ -390,7 +297,7 @@ When [`settings.listItemIndent`](https://github.com/remarkjs/remark/tree/main/pa
 
 ##### `not-ok.md`
 
-When configured with `'tab'`.
+When [`settings.listItemIndent`](https://github.com/remarkjs/remark-lint#configure) is `'tab'` and the rule is not configured.
 
 ###### In
 
@@ -409,36 +316,7 @@ When configured with `'tab'`.
 
 ##### `not-ok.md`
 
-When [`settings.listItemIndent`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent) is `'tab'` and the rule is not configured.
-
-###### In
-
-> 👉 **Note**: `·` represents a space.
-
-```markdown
-*·List
-··item.
-```
-
-###### Out
-
-```text
-1:3: Incorrect list-item indent: add 2 spaces
-```
-
-##### `not-ok.md`
-
-When configured with `'💩'`.
-
-###### Out
-
-```text
-1:1: Incorrect list-item indent style `💩`: use either `'tab'`, `'one'`, or `'mixed'`
-```
-
-##### `not-ok.md`
-
-When [`settings.listItemIndent`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent) is `'💩'` and the rule is not configured.
+When [`settings.listItemIndent`](https://github.com/remarkjs/remark-lint#configure) is `'💩'` and the rule is not configured.
 
 ###### Out
 

--- a/packages/remark-lint-list-item-indent/readme.md
+++ b/packages/remark-lint-list-item-indent/readme.md
@@ -47,7 +47,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'mixed'` |
-| [`remark-preset-lint-recommended`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-recommended) | `'tab-size'` |
+| [`remark-preset-lint-recommended`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-recommended) | `'tab'` |
 
 ## Install
 
@@ -126,14 +126,14 @@ The default export is `remarkLintListItemIndent`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: `'tab-size'`) are accepted:
+The following options (default: `'tab'`) are accepted:
 
-*   `'space'`
+*   `'one'`
     — prefer a single space
-*   `'tab-size'`
+*   `'tab'`
     — prefer spaces the size of the next tab stop
 *   `'mixed'`
-    — prefer `'space'` for tight lists and `'tab-size'` for loose lists
+    — prefer `'one'` for tight lists and `'tab'` for loose lists
 
 ## Recommendation
 
@@ -159,17 +159,17 @@ Historically, how indentation of lists works in markdown has been a mess,
 especially with how they interact with indented code.
 CommonMark made that a *lot* better, but there remain (documented but
 complex) edge cases and some behavior intuitive.
-Due to this, the default of this list is `'tab-size'`, which worked the best
+Due to this, the default of this list is `'tab'`, which worked the best
 in most markdown parsers.
 Currently, the situation between markdown parsers is better, so choosing
-`'space'` (which seems to be the most common style used by authors) should
+`'one'` (which seems to be the most common style used by authors) should
 be okay.
 
 ## Fix
 
 [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
-uses `'tab-size'` (named `'tab'` there) by default.
-[`listItemIndent: '1'` (for `'space'`) or `listItemIndent: 'mixed'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent)
+uses `'tab'` by default.
+[`listItemIndent: 'one'` or `listItemIndent: 'mixed'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent)
 is supported.
 
 ## Examples
@@ -250,7 +250,7 @@ When configured with `'mixed'`.
 
 ##### `ok.md`
 
-When configured with `'space'`.
+When configured with `'one'`.
 
 ###### In
 
@@ -278,7 +278,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'space'`.
+When configured with `'one'`.
 
 ###### In
 
@@ -297,7 +297,7 @@ When configured with `'space'`.
 
 ##### `not-ok.md`
 
-When configured with `'tab-size'`.
+When configured with `'tab'`.
 
 ###### In
 
@@ -321,7 +321,7 @@ When configured with `'💩'`.
 ###### Out
 
 ```text
-1:1: Incorrect list-item indent style `💩`: use either `'tab-size'`, `'space'`, or `'mixed'`
+1:1: Incorrect list-item indent style `💩`: use either `'tab'`, `'one'`, or `'mixed'`
 ```
 
 ## Compatibility

--- a/packages/remark-lint-list-item-indent/readme.md
+++ b/packages/remark-lint-list-item-indent/readme.md
@@ -46,8 +46,8 @@ This rule is included in the following presets:
 
 | Preset | Setting |
 | - | - |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | |
-| [`remark-preset-lint-recommended`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-recommended) | |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'mixed'` |
+| [`remark-preset-lint-recommended`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-recommended) | `'tab'` |
 
 ## Install
 

--- a/packages/remark-lint-list-item-indent/readme.md
+++ b/packages/remark-lint-list-item-indent/readme.md
@@ -46,8 +46,8 @@ This rule is included in the following presets:
 
 | Preset | Setting |
 | - | - |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'mixed'` |
-| [`remark-preset-lint-recommended`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-recommended) | `'tab'` |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | |
+| [`remark-preset-lint-recommended`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-recommended) | |
 
 ## Install
 

--- a/packages/remark-lint-list-item-indent/readme.md
+++ b/packages/remark-lint-list-item-indent/readme.md
@@ -126,14 +126,14 @@ The default export is `remarkLintListItemIndent`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: [`settings.listItemIndent`](https://github.com/remarkjs/remark-lint#configure) or `'tab'`) are accepted:
+The following options (default: [`settings.listItemIndent`](https://github.com/remarkjs/remark-lint#configure) or `'tab-size'`) are accepted:
 
-*   `'one'`
+*   `'space'`
     — prefer a single space
-*   `'tab'`
+*   `'tab-size'`
     — prefer spaces the size of the next tab stop
 *   `'mixed'`
-    — prefer `'one'` for tight lists and `'tab'` for loose lists
+    — prefer `'space'` for tight lists and `'tab-size'` for loose lists
 
 ## Recommendation
 
@@ -159,17 +159,17 @@ Historically, how indentation of lists works in markdown has been a mess,
 especially with how they interact with indented code.
 CommonMark made that a *lot* better, but there remain (documented but
 complex) edge cases and some behavior intuitive.
-Due to this, the default of this list is `'tab'`, which worked the best
+Due to this, the default of this list is `'tab-size'`, which worked the best
 in most markdown parsers.
 Currently, the situation between markdown parsers is better, so choosing
-`'one'` (which seems to be the most common style used by authors) should
+`'space'` (which seems to be the most common style used by authors) should
 be okay.
 
 ## Fix
 
 [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
-uses `'tab'` by default.
-[`settings.listItemIndent: 'one'` or `settings.listItemIndent: 'mixed'`](https://github.com/remarkjs/remark-lint#configure)
+uses `'tab-size'` (named `'tab'` there) by default.
+[`settings.listItemIndent: '1'` (for `'space'`) or `settings.listItemIndent: 'mixed'`](https://github.com/remarkjs/remark-lint#configure)
 is supported.
 
 ## Examples
@@ -316,12 +316,12 @@ When [`settings.listItemIndent`](https://github.com/remarkjs/remark-lint#configu
 
 ##### `not-ok.md`
 
-When [`settings.listItemIndent`](https://github.com/remarkjs/remark-lint#configure) is `'💩'` and the rule is not configured.
+When configured with `'💩'`.
 
 ###### Out
 
 ```text
-1:1: Incorrect list-item indent style `💩`: use either `'tab'`, `'one'`, or `'mixed'`
+1:1: Incorrect list-item indent style `💩`: use either `'tab-size'`, `'space'`, or `'mixed'`
 ```
 
 ## Compatibility

--- a/packages/remark-lint-list-item-indent/readme.md
+++ b/packages/remark-lint-list-item-indent/readme.md
@@ -250,7 +250,7 @@ When configured with `'mixed'`.
 
 ##### `ok.md`
 
-When configured with [`settings.listItemIndent: 'mixed'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent).
+When [`settings.listItemIndent`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent) is `'mixed'` and the rule is not configured.
 
 ###### In
 
@@ -278,7 +278,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with [`settings.listItemIndent: 'mixed'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent).
+When [`settings.listItemIndent`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent) is `'mixed'` and the rule is not configured.
 
 ###### In
 
@@ -343,7 +343,7 @@ When configured with `'one'`.
 
 ##### `ok.md`
 
-When configured with [`settings.listItemIndent: 'one'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent).
+When [`settings.listItemIndent`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent) is `'one'` and the rule is not configured.
 
 ###### In
 
@@ -371,7 +371,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with [`settings.listItemIndent: 'one'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent).
+When [`settings.listItemIndent`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent) is `'one'` and the rule is not configured.
 
 ###### In
 
@@ -409,7 +409,7 @@ When configured with `'tab'`.
 
 ##### `not-ok.md`
 
-When configured with [`settings.listItemIndent: 'tab'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent).
+When [`settings.listItemIndent`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent) is `'tab'` and the rule is not configured.
 
 ###### In
 
@@ -438,7 +438,7 @@ When configured with `'💩'`.
 
 ##### `not-ok.md`
 
-When configured with [`settings.listItemIndent: '💩'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent).
+When [`settings.listItemIndent`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent) is `'💩'` and the rule is not configured.
 
 ###### Out
 

--- a/packages/remark-lint-list-item-indent/readme.md
+++ b/packages/remark-lint-list-item-indent/readme.md
@@ -204,6 +204,52 @@ No messages.
 
 ##### `ok.md`
 
+When configured with `'mixed'`.
+
+###### In
+
+> 👉 **Note**: `·` represents a space.
+
+```markdown
+*·List item.
+
+Paragraph.
+
+11.·List item
+
+Paragraph.
+
+*···List
+····item.
+
+*···List
+····item.
+```
+
+###### Out
+
+No messages.
+
+##### `not-ok.md`
+
+When configured with `'mixed'`.
+
+###### In
+
+> 👉 **Note**: `·` represents a space.
+
+```markdown
+*···List item.
+```
+
+###### Out
+
+```text
+1:5: Incorrect list-item indent: remove 2 spaces
+```
+
+##### `ok.md`
+
 When configured with [`settings.listItemIndent: 'mixed'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent).
 
 ###### In
@@ -240,6 +286,53 @@ When configured with [`settings.listItemIndent: 'mixed'`](https://github.com/rem
 
 ```markdown
 *···List item.
+```
+
+###### Out
+
+```text
+1:5: Incorrect list-item indent: remove 2 spaces
+```
+
+##### `ok.md`
+
+When configured with `'one'`.
+
+###### In
+
+> 👉 **Note**: `·` represents a space.
+
+```markdown
+*·List item.
+
+Paragraph.
+
+11.·List item
+
+Paragraph.
+
+*·List
+··item.
+
+*·List
+··item.
+```
+
+###### Out
+
+No messages.
+
+##### `not-ok.md`
+
+When configured with `'one'`.
+
+###### In
+
+> 👉 **Note**: `·` represents a space.
+
+```markdown
+*···List
+····item.
 ```
 
 ###### Out
@@ -297,6 +390,25 @@ When configured with [`settings.listItemIndent: 'one'`](https://github.com/remar
 
 ##### `not-ok.md`
 
+When configured with `'tab'`.
+
+###### In
+
+> 👉 **Note**: `·` represents a space.
+
+```markdown
+*·List
+··item.
+```
+
+###### Out
+
+```text
+1:3: Incorrect list-item indent: add 2 spaces
+```
+
+##### `not-ok.md`
+
 When configured with [`settings.listItemIndent: 'tab'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent).
 
 ###### In
@@ -312,6 +424,16 @@ When configured with [`settings.listItemIndent: 'tab'`](https://github.com/remar
 
 ```text
 1:3: Incorrect list-item indent: add 2 spaces
+```
+
+##### `not-ok.md`
+
+When configured with `'💩'`.
+
+###### Out
+
+```text
+1:1: Incorrect list-item indent style `💩`: use either `'tab'`, `'one'`, or `'mixed'`
 ```
 
 ##### `not-ok.md`

--- a/packages/remark-lint-ordered-list-marker-style/index.js
+++ b/packages/remark-lint-ordered-list-marker-style/index.js
@@ -5,7 +5,7 @@
  *
  * ## API
  *
- * The following options (default: `'consistent'`) are accepted:
+ * The following options (default: [`settings.bulletOrdered`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbulletordered) or `'consistent'`) are accepted:
  *
  * *   `'.'`
  *     — prefer dots
@@ -48,14 +48,14 @@
  *   * Foo
  *
  * @example
- *   {"name": "ok.md", "config": "."}
+ *   {"name": "ok.md", "settings": {"bulletOrdered": "."}}
  *
  *   1.  Foo
  *
  *   2.  Bar
  *
  * @example
- *   {"name": "ok.md", "config": ")"}
+ *   {"name": "ok.md", "settings": {"bulletOrdered": ")"}}
  *
  *   1)  Foo
  *
@@ -74,7 +74,7 @@
  *   3:1-3:8: Marker style should be `.`
  *
  * @example
- *   {"name": "not-ok.md", "label": "output", "config": "💩", "positionless": true}
+ *   {"name": "not-ok.md", "label": "output", "settings": {"bulletOrdered": "💩"}, "positionless": true}
  *
  *   1:1: Incorrect ordered list item marker style `💩`: use either `'.'` or `')'`
  */
@@ -96,8 +96,13 @@ const remarkLintOrderedListMarkerStyle = lintRule(
     url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-style#readme'
   },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
-  (tree, file, option = 'consistent') => {
+  function (tree, file, option) {
     const value = String(file)
+
+    if (!option) {
+      const {settings} = this.data()
+      option = (settings && settings.bulletOrdered) || 'consistent'
+    }
 
     if (option !== 'consistent' && option !== '.' && option !== ')') {
       file.fail(

--- a/packages/remark-lint-ordered-list-marker-style/index.js
+++ b/packages/remark-lint-ordered-list-marker-style/index.js
@@ -5,7 +5,7 @@
  *
  * ## API
  *
- * The following options (default: [`settings.bulletOrdered`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbulletordered) or `'consistent'`) are accepted:
+ * The following options (default: [`settings.bulletOrdered`](https://github.com/remarkjs/remark-lint#configure) or `'consistent'`) are accepted:
  *
  * *   `'.'`
  *     — prefer dots
@@ -25,8 +25,8 @@
  *
  * [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
  * formats ordered lists with dots by default.
- * Pass
- * [`bulletOrdered: ')'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbulletordered)
+ * Change
+ * [`settings.bulletOrdered`](https://github.com/remarkjs/remark-lint#configure) to `')'`
  * to always use parens.
  *
  * @module ordered-list-marker-style

--- a/packages/remark-lint-ordered-list-marker-style/index.js
+++ b/packages/remark-lint-ordered-list-marker-style/index.js
@@ -119,8 +119,9 @@ const remarkLintOrderedListMarkerStyle = lintRule(
     const value = String(file)
 
     if (!option) {
-      const {settings} = this.data()
-      option = (settings && settings.bulletOrdered) || 'consistent'
+      /** @type {import('remark-stringify').Options} */
+      const settings = this.data().settings || {}
+      option = settings.bulletOrdered || 'consistent'
     }
 
     if (option !== 'consistent' && option !== '.' && option !== ')') {

--- a/packages/remark-lint-ordered-list-marker-style/index.js
+++ b/packages/remark-lint-ordered-list-marker-style/index.js
@@ -48,11 +48,25 @@
  *   * Foo
  *
  * @example
+ *   {"name": "ok.md", "config": "."}
+ *
+ *   1.  Foo
+ *
+ *   2.  Bar
+ *
+ * @example
  *   {"name": "ok.md", "settings": {"bulletOrdered": "."}}
  *
  *   1.  Foo
  *
  *   2.  Bar
+ *
+ * @example
+ *   {"name": "ok.md", "config": ")"}
+ *
+ *   1)  Foo
+ *
+ *   2)  Bar
  *
  * @example
  *   {"name": "ok.md", "settings": {"bulletOrdered": ")"}}
@@ -72,6 +86,11 @@
  *   {"name": "not-ok.md", "label": "output"}
  *
  *   3:1-3:8: Marker style should be `.`
+ *
+ * @example
+ *   {"name": "not-ok.md", "label": "output", "config": "💩", "positionless": true}
+ *
+ *   1:1: Incorrect ordered list item marker style `💩`: use either `'.'` or `')'`
  *
  * @example
  *   {"name": "not-ok.md", "label": "output", "settings": {"bulletOrdered": "💩"}, "positionless": true}

--- a/packages/remark-lint-ordered-list-marker-style/readme.md
+++ b/packages/remark-lint-ordered-list-marker-style/readme.md
@@ -45,8 +45,8 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'.'` |
-| [`remark-preset-lint-recommended`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-recommended) | `'.'` |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | |
+| [`remark-preset-lint-recommended`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-recommended) | |
 
 ## Install
 

--- a/packages/remark-lint-ordered-list-marker-style/readme.md
+++ b/packages/remark-lint-ordered-list-marker-style/readme.md
@@ -45,8 +45,8 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'.'` |
-| [`remark-preset-lint-recommended`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-recommended) | `'.'` |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | [`settings.bulletOrdered`](https://github.com/remarkjs/remark-lint#configure) is `'.'` |
+| [`remark-preset-lint-recommended`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-recommended) | [`settings.bulletOrdered`](https://github.com/remarkjs/remark-lint#configure) is `'.'` |
 
 ## Install
 
@@ -125,7 +125,7 @@ The default export is `remarkLintOrderedListMarkerStyle`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: [`settings.bulletOrdered`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbulletordered) or `'consistent'`) are accepted:
+The following options (default: [`settings.bulletOrdered`](https://github.com/remarkjs/remark-lint#configure) or `'consistent'`) are accepted:
 
 *   `'.'`
     — prefer dots
@@ -145,8 +145,8 @@ Due to this, it’s recommended to prefer dots.
 
 [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
 formats ordered lists with dots by default.
-Pass
-[`bulletOrdered: ')'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbulletordered)
+Change
+[`settings.bulletOrdered`](https://github.com/remarkjs/remark-lint#configure) to `')'`
 to always use parens.
 
 ## Examples
@@ -188,7 +188,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with `'.'`.
+When [`settings.bulletOrdered`](https://github.com/remarkjs/remark-lint#configure) is `'.'` and the rule is not configured.
 
 ###### In
 
@@ -204,39 +204,7 @@ No messages.
 
 ##### `ok.md`
 
-When [`settings.bulletOrdered`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbulletordered) is `'.'` and the rule is not configured.
-
-###### In
-
-```markdown
-1.  Foo
-
-2.  Bar
-```
-
-###### Out
-
-No messages.
-
-##### `ok.md`
-
-When configured with `')'`.
-
-###### In
-
-```markdown
-1)  Foo
-
-2)  Bar
-```
-
-###### Out
-
-No messages.
-
-##### `ok.md`
-
-When [`settings.bulletOrdered`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbulletordered) is `')'` and the rule is not configured.
+When [`settings.bulletOrdered`](https://github.com/remarkjs/remark-lint#configure) is `')'` and the rule is not configured.
 
 ###### In
 
@@ -252,17 +220,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'💩'`.
-
-###### Out
-
-```text
-1:1: Incorrect ordered list item marker style `💩`: use either `'.'` or `')'`
-```
-
-##### `not-ok.md`
-
-When [`settings.bulletOrdered`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbulletordered) is `'💩'` and the rule is not configured.
+When [`settings.bulletOrdered`](https://github.com/remarkjs/remark-lint#configure) is `'💩'` and the rule is not configured.
 
 ###### Out
 

--- a/packages/remark-lint-ordered-list-marker-style/readme.md
+++ b/packages/remark-lint-ordered-list-marker-style/readme.md
@@ -45,8 +45,8 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | |
-| [`remark-preset-lint-recommended`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-recommended) | |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'.'` |
+| [`remark-preset-lint-recommended`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-recommended) | `'.'` |
 
 ## Install
 

--- a/packages/remark-lint-ordered-list-marker-style/readme.md
+++ b/packages/remark-lint-ordered-list-marker-style/readme.md
@@ -125,7 +125,7 @@ The default export is `remarkLintOrderedListMarkerStyle`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: `'consistent'`) are accepted:
+The following options (default: [`settings.bulletOrdered`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbulletordered) or `'consistent'`) are accepted:
 
 *   `'.'`
     — prefer dots
@@ -188,7 +188,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with `'.'`.
+When configured with [`settings.bulletOrdered: '.'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbulletordered).
 
 ###### In
 
@@ -204,7 +204,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with `')'`.
+When configured with [`settings.bulletOrdered: ')'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbulletordered).
 
 ###### In
 
@@ -220,7 +220,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'💩'`.
+When configured with [`settings.bulletOrdered: '💩'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbulletordered).
 
 ###### Out
 

--- a/packages/remark-lint-ordered-list-marker-style/readme.md
+++ b/packages/remark-lint-ordered-list-marker-style/readme.md
@@ -188,6 +188,22 @@ No messages.
 
 ##### `ok.md`
 
+When configured with `'.'`.
+
+###### In
+
+```markdown
+1.  Foo
+
+2.  Bar
+```
+
+###### Out
+
+No messages.
+
+##### `ok.md`
+
 When configured with [`settings.bulletOrdered: '.'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbulletordered).
 
 ###### In
@@ -196,6 +212,22 @@ When configured with [`settings.bulletOrdered: '.'`](https://github.com/remarkjs
 1.  Foo
 
 2.  Bar
+```
+
+###### Out
+
+No messages.
+
+##### `ok.md`
+
+When configured with `')'`.
+
+###### In
+
+```markdown
+1)  Foo
+
+2)  Bar
 ```
 
 ###### Out
@@ -217,6 +249,16 @@ When configured with [`settings.bulletOrdered: ')'`](https://github.com/remarkjs
 ###### Out
 
 No messages.
+
+##### `not-ok.md`
+
+When configured with `'💩'`.
+
+###### Out
+
+```text
+1:1: Incorrect ordered list item marker style `💩`: use either `'.'` or `')'`
+```
 
 ##### `not-ok.md`
 

--- a/packages/remark-lint-ordered-list-marker-style/readme.md
+++ b/packages/remark-lint-ordered-list-marker-style/readme.md
@@ -204,7 +204,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with [`settings.bulletOrdered: '.'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbulletordered).
+When [`settings.bulletOrdered`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbulletordered) is `'.'` and the rule is not configured.
 
 ###### In
 
@@ -236,7 +236,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with [`settings.bulletOrdered: ')'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbulletordered).
+When [`settings.bulletOrdered`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbulletordered) is `')'` and the rule is not configured.
 
 ###### In
 
@@ -262,7 +262,7 @@ When configured with `'💩'`.
 
 ##### `not-ok.md`
 
-When configured with [`settings.bulletOrdered: '💩'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbulletordered).
+When [`settings.bulletOrdered`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbulletordered) is `'💩'` and the rule is not configured.
 
 ###### Out
 

--- a/packages/remark-lint-ordered-list-marker-value/index.js
+++ b/packages/remark-lint-ordered-list-marker-value/index.js
@@ -5,7 +5,7 @@
  *
  * ## API
  *
- * The following options (default: [`settings.incrementListMarker`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsincrementlistmarker) or `'ordered'`) are accepted:
+ * The following options (default: [`settings.incrementListMarker`](https://github.com/remarkjs/remark-lint#configure) or `'ordered'`) are accepted:
  *
  * *   `'ordered'`
  *     — values should increment by one from the first item
@@ -29,8 +29,8 @@
  *
  * [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
  * retains the value of the first item and increments further items by default.
- * Pass
- * [`incrementListMarker: false`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsincrementlistmarker)
+ * Change
+ * [`settings.incrementListMarker`](https://github.com/remarkjs/remark-lint#configure) to `false`
  * to not increment further items.
  *
  * @module ordered-list-marker-value

--- a/packages/remark-lint-ordered-list-marker-value/index.js
+++ b/packages/remark-lint-ordered-list-marker-value/index.js
@@ -73,6 +73,25 @@
  *   1.  Charlie
  *
  * @example
+ *   {"name": "ok.md", "config": "single"}
+ *
+ *   1.  Foo
+ *   1.  Bar
+ *   1.  Baz
+ *
+ *   Paragraph.
+ *
+ *   3.  Alpha
+ *   3.  Bravo
+ *   3.  Charlie
+ *
+ *   Paragraph.
+ *
+ *   0.  Delta
+ *   0.  Echo
+ *   0.  Foxtrot
+ *
+ * @example
  *   {"name": "ok.md", "settings": {"incrementListMarker": false}}
  *
  *   1.  Foo
@@ -90,6 +109,25 @@
  *   0.  Delta
  *   0.  Echo
  *   0.  Foxtrot
+ *
+ * @example
+ *   {"name": "ok.md", "config": "ordered"}
+ *
+ *   1.  Foo
+ *   2.  Bar
+ *   3.  Baz
+ *
+ *   Paragraph.
+ *
+ *   3.  Alpha
+ *   4.  Bravo
+ *   5.  Charlie
+ *
+ *   Paragraph.
+ *
+ *   0.  Delta
+ *   1.  Echo
+ *   2.  Foxtrot
  *
  * @example
  *   {"name": "ok.md", "settings": {"incrementListMarker": true}}
@@ -131,6 +169,17 @@
  *   {"name": "also-not-ok.md", "config": "one", "label": "output"}
  *
  *   1:1-1:8: Marker should be `1`, was `2`
+ *
+ * @example
+ *   {"name": "not-ok.md", "config": "ordered", "label": "input"}
+ *
+ *   1.  Foo
+ *   1.  Bar
+ *
+ * @example
+ *   {"name": "not-ok.md", "config": "ordered", "label": "output"}
+ *
+ *   2:1-2:8: Marker should be `2`, was `1`
  *
  * @example
  *   {"name": "not-ok.md", "settings": {"incrementListMarker": true}, "label": "input"}

--- a/packages/remark-lint-ordered-list-marker-value/index.js
+++ b/packages/remark-lint-ordered-list-marker-value/index.js
@@ -5,7 +5,7 @@
  *
  * ## API
  *
- * The following options (default: `'ordered'`) are accepted:
+ * The following options (default: [`settings.incrementListMarker`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsincrementlistmarker) or `'ordered'`) are accepted:
  *
  * *   `'ordered'`
  *     — values should increment by one from the first item
@@ -73,7 +73,7 @@
  *   1.  Charlie
  *
  * @example
- *   {"name": "ok.md", "config": "single"}
+ *   {"name": "ok.md", "settings": {"incrementListMarker": false}}
  *
  *   1.  Foo
  *   1.  Bar
@@ -92,7 +92,7 @@
  *   0.  Foxtrot
  *
  * @example
- *   {"name": "ok.md", "config": "ordered"}
+ *   {"name": "ok.md", "settings": {"incrementListMarker": true}}
  *
  *   1.  Foo
  *   2.  Bar
@@ -133,13 +133,13 @@
  *   1:1-1:8: Marker should be `1`, was `2`
  *
  * @example
- *   {"name": "not-ok.md", "config": "ordered", "label": "input"}
+ *   {"name": "not-ok.md", "settings": {"incrementListMarker": true}, "label": "input"}
  *
  *   1.  Foo
  *   1.  Bar
  *
  * @example
- *   {"name": "not-ok.md", "config": "ordered", "label": "output"}
+ *   {"name": "not-ok.md", "settings": {"incrementListMarker": true}, "label": "output"}
  *
  *   2:1-2:8: Marker should be `2`, was `1`
  *
@@ -165,8 +165,18 @@ const remarkLintOrderedListMarkerValue = lintRule(
     url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-value#readme'
   },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
-  (tree, file, option = 'ordered') => {
+  function (tree, file, option) {
     const value = String(file)
+
+    if (!option) {
+      const {settings} = this.data()
+      option =
+        !settings ||
+        settings.incrementListMarker === undefined ||
+        settings.incrementListMarker
+          ? 'ordered'
+          : 'single'
+    }
 
     if (option !== 'ordered' && option !== 'one' && option !== 'single') {
       file.fail(

--- a/packages/remark-lint-ordered-list-marker-value/index.js
+++ b/packages/remark-lint-ordered-list-marker-value/index.js
@@ -218,13 +218,9 @@ const remarkLintOrderedListMarkerValue = lintRule(
     const value = String(file)
 
     if (!option) {
-      const {settings} = this.data()
-      option =
-        !settings ||
-        settings.incrementListMarker === undefined ||
-        settings.incrementListMarker
-          ? 'ordered'
-          : 'single'
+      /** @type {import('remark-stringify').Options} */
+      const settings = this.data().settings || {}
+      option = settings.incrementListMarker === false ? 'single' : 'ordered'
     }
 
     if (option !== 'ordered' && option !== 'one' && option !== 'single') {

--- a/packages/remark-lint-ordered-list-marker-value/readme.md
+++ b/packages/remark-lint-ordered-list-marker-value/readme.md
@@ -123,7 +123,7 @@ The default export is `remarkLintOrderedListMarkerValue`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: [`settings.incrementListMarker`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsincrementlistmarker) or `'ordered'`) are accepted:
+The following options (default: [`settings.incrementListMarker`](https://github.com/remarkjs/remark-lint#configure) or `'ordered'`) are accepted:
 
 *   `'ordered'`
     — values should increment by one from the first item
@@ -147,8 +147,8 @@ choice.
 
 [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
 retains the value of the first item and increments further items by default.
-Pass
-[`incrementListMarker: false`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsincrementlistmarker)
+Change
+[`settings.incrementListMarker`](https://github.com/remarkjs/remark-lint#configure) to `false`
 to not increment further items.
 
 ## Examples
@@ -238,7 +238,7 @@ When configured with `'one'`.
 
 ##### `ok.md`
 
-When configured with `'single'`.
+When [`settings.incrementListMarker`](https://github.com/remarkjs/remark-lint#configure) is `false` and the rule is not configured.
 
 ###### In
 
@@ -266,35 +266,7 @@ No messages.
 
 ##### `ok.md`
 
-When [`settings.incrementListMarker`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsincrementlistmarker) is `false` and the rule is not configured.
-
-###### In
-
-```markdown
-1.  Foo
-1.  Bar
-1.  Baz
-
-Paragraph.
-
-3.  Alpha
-3.  Bravo
-3.  Charlie
-
-Paragraph.
-
-0.  Delta
-0.  Echo
-0.  Foxtrot
-```
-
-###### Out
-
-No messages.
-
-##### `ok.md`
-
-When configured with `'ordered'`.
+When [`settings.incrementListMarker`](https://github.com/remarkjs/remark-lint#configure) is `true` and the rule is not configured.
 
 ###### In
 
@@ -322,52 +294,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'ordered'`.
-
-###### In
-
-```markdown
-1.  Foo
-1.  Bar
-```
-
-###### Out
-
-```text
-2:1-2:8: Marker should be `2`, was `1`
-```
-
-##### `ok.md`
-
-When [`settings.incrementListMarker`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsincrementlistmarker) is `true` and the rule is not configured.
-
-###### In
-
-```markdown
-1.  Foo
-2.  Bar
-3.  Baz
-
-Paragraph.
-
-3.  Alpha
-4.  Bravo
-5.  Charlie
-
-Paragraph.
-
-0.  Delta
-1.  Echo
-2.  Foxtrot
-```
-
-###### Out
-
-No messages.
-
-##### `not-ok.md`
-
-When [`settings.incrementListMarker`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsincrementlistmarker) is `true` and the rule is not configured.
+When [`settings.incrementListMarker`](https://github.com/remarkjs/remark-lint#configure) is `true` and the rule is not configured.
 
 ###### In
 

--- a/packages/remark-lint-ordered-list-marker-value/readme.md
+++ b/packages/remark-lint-ordered-list-marker-value/readme.md
@@ -266,7 +266,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with [`settings.incrementListMarker: false`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsincrementlistmarker).
+When [`settings.incrementListMarker`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsincrementlistmarker) is `false` and the rule is not configured.
 
 ###### In
 
@@ -339,7 +339,7 @@ When configured with `'ordered'`.
 
 ##### `ok.md`
 
-When configured with [`settings.incrementListMarker: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsincrementlistmarker).
+When [`settings.incrementListMarker`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsincrementlistmarker) is `true` and the rule is not configured.
 
 ###### In
 
@@ -367,7 +367,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with [`settings.incrementListMarker: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsincrementlistmarker).
+When [`settings.incrementListMarker`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsincrementlistmarker) is `true` and the rule is not configured.
 
 ###### In
 

--- a/packages/remark-lint-ordered-list-marker-value/readme.md
+++ b/packages/remark-lint-ordered-list-marker-value/readme.md
@@ -123,7 +123,7 @@ The default export is `remarkLintOrderedListMarkerValue`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: `'ordered'`) are accepted:
+The following options (default: [`settings.incrementListMarker`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsincrementlistmarker) or `'ordered'`) are accepted:
 
 *   `'ordered'`
     — values should increment by one from the first item
@@ -238,7 +238,7 @@ When configured with `'one'`.
 
 ##### `ok.md`
 
-When configured with `'single'`.
+When configured with [`settings.incrementListMarker: false`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsincrementlistmarker).
 
 ###### In
 
@@ -266,7 +266,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with `'ordered'`.
+When configured with [`settings.incrementListMarker: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsincrementlistmarker).
 
 ###### In
 
@@ -294,7 +294,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'ordered'`.
+When configured with [`settings.incrementListMarker: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsincrementlistmarker).
 
 ###### In
 

--- a/packages/remark-lint-ordered-list-marker-value/readme.md
+++ b/packages/remark-lint-ordered-list-marker-value/readme.md
@@ -238,6 +238,34 @@ When configured with `'one'`.
 
 ##### `ok.md`
 
+When configured with `'single'`.
+
+###### In
+
+```markdown
+1.  Foo
+1.  Bar
+1.  Baz
+
+Paragraph.
+
+3.  Alpha
+3.  Bravo
+3.  Charlie
+
+Paragraph.
+
+0.  Delta
+0.  Echo
+0.  Foxtrot
+```
+
+###### Out
+
+No messages.
+
+##### `ok.md`
+
 When configured with [`settings.incrementListMarker: false`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsincrementlistmarker).
 
 ###### In
@@ -263,6 +291,51 @@ Paragraph.
 ###### Out
 
 No messages.
+
+##### `ok.md`
+
+When configured with `'ordered'`.
+
+###### In
+
+```markdown
+1.  Foo
+2.  Bar
+3.  Baz
+
+Paragraph.
+
+3.  Alpha
+4.  Bravo
+5.  Charlie
+
+Paragraph.
+
+0.  Delta
+1.  Echo
+2.  Foxtrot
+```
+
+###### Out
+
+No messages.
+
+##### `not-ok.md`
+
+When configured with `'ordered'`.
+
+###### In
+
+```markdown
+1.  Foo
+1.  Bar
+```
+
+###### Out
+
+```text
+2:1-2:8: Marker should be `2`, was `1`
+```
 
 ##### `ok.md`
 

--- a/packages/remark-lint-rule-style/index.js
+++ b/packages/remark-lint-rule-style/index.js
@@ -43,11 +43,25 @@
  * @copyright 2015 Titus Wormer
  * @license MIT
  * @example
+ *   {"name": "ok.md", "config": "* * *"}
+ *
+ *   * * *
+ *
+ *   * * *
+ *
+ * @example
  *   {"name": "ok.md", "settings": {"ruleSpaces": true}}
  *
  *   * * *
  *
  *   * * *
+ *
+ * @example
+ *   {"name": "ok.md", "config": "_______"}
+ *
+ *   _______
+ *
+ *   _______
  *
  * @example
  *   {"name": "ok.md", "settings": {"rule": "_", "ruleRepetition": 7}}

--- a/packages/remark-lint-rule-style/index.js
+++ b/packages/remark-lint-rule-style/index.js
@@ -6,7 +6,7 @@
  *
  * ## API
  *
- * The following options (default: [`settings.rule`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrule), [`settings.ruleRepetition`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulerepetition), [`settings.ruleSpaces`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulespaces), or `'consistent'`) are accepted:
+ * The following options (default: [`settings.rule`](https://github.com/remarkjs/remark-lint#configure), [`settings.ruleRepetition`](https://github.com/remarkjs/remark-lint#configure), [`settings.ruleSpaces`](https://github.com/remarkjs/remark-lint#configure), or `'consistent'`) are accepted:
  *
  * *   `string` (example: `'** * **'`, `'___'`)
  *     — thematic break to prefer
@@ -29,11 +29,11 @@
  * formats rules with `***` by default.
  * There are three settings to control rules:
  *
- * *   [`rule`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrule)
+ * *   [`settings.rule`](https://github.com/remarkjs/remark-lint#configure)
  *     (default: `'*'`) — marker
- * *   [`ruleRepetition`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulerepetition)
+ * *   [`settings.ruleRepetition`](https://github.com/remarkjs/remark-lint#configure)
  *     (default: `3`) — repetitions
- * *   [`ruleSpaces`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulespaces)
+ * *   [`settings.ruleSpaces`](https://github.com/remarkjs/remark-lint#configure)
  *     (default: `false`) — use spaces between markers
  *
  * @module rule-style

--- a/packages/remark-lint-rule-style/index.js
+++ b/packages/remark-lint-rule-style/index.js
@@ -108,14 +108,14 @@ const remarkLintRuleStyle = lintRule(
     const value = String(file)
 
     if (!option) {
-      const {settings} = this.data()
+      /** @type {import('remark-stringify').Options} */
+      const settings = this.data().settings || {}
       option =
-        !settings ||
-        (settings.rule === undefined &&
-          settings.ruleRepetition === undefined &&
-          settings.ruleSpaces === undefined)
-          ? 'consistent'
-          : toMarkdown({type: 'thematicBreak'}, settings).slice(0, -1)
+        settings.rule !== undefined ||
+        settings.ruleRepetition !== undefined ||
+        typeof settings.ruleSpaces === 'boolean'
+          ? toMarkdown({type: 'thematicBreak'}, settings).slice(0, -1)
+          : 'consistent'
     }
 
     if (option !== 'consistent' && /[^-_* ]/.test(option)) {

--- a/packages/remark-lint-rule-style/readme.md
+++ b/packages/remark-lint-rule-style/readme.md
@@ -46,7 +46,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'---'` |
 
 ## Install
 

--- a/packages/remark-lint-rule-style/readme.md
+++ b/packages/remark-lint-rule-style/readme.md
@@ -125,7 +125,7 @@ The default export is `remarkLintRuleStyle`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: `'consistent'`) are accepted:
+The following options (default: [`settings.rule`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrule), [`settings.ruleRepetition`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulerepetition), [`settings.ruleSpaces`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulespaces), or `'consistent'`) are accepted:
 
 *   `string` (example: `'** * **'`, `'___'`)
     — thematic break to prefer
@@ -159,7 +159,7 @@ There are three settings to control rules:
 
 ##### `ok.md`
 
-When configured with `'* * *'`.
+When configured with [`settings.ruleSpaces: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulespaces).
 
 ###### In
 
@@ -175,7 +175,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with `'_______'`.
+When configured with [`settings.rule: '_'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrule), [`settings.ruleRepetition: 7`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulerepetition).
 
 ###### In
 

--- a/packages/remark-lint-rule-style/readme.md
+++ b/packages/remark-lint-rule-style/readme.md
@@ -46,7 +46,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'---'` |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | |
 
 ## Install
 

--- a/packages/remark-lint-rule-style/readme.md
+++ b/packages/remark-lint-rule-style/readme.md
@@ -159,6 +159,22 @@ There are three settings to control rules:
 
 ##### `ok.md`
 
+When configured with `'* * *'`.
+
+###### In
+
+```markdown
+* * *
+
+* * *
+```
+
+###### Out
+
+No messages.
+
+##### `ok.md`
+
 When configured with [`settings.ruleSpaces: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulespaces).
 
 ###### In
@@ -167,6 +183,22 @@ When configured with [`settings.ruleSpaces: true`](https://github.com/remarkjs/r
 * * *
 
 * * *
+```
+
+###### Out
+
+No messages.
+
+##### `ok.md`
+
+When configured with `'_______'`.
+
+###### In
+
+```markdown
+_______
+
+_______
 ```
 
 ###### Out

--- a/packages/remark-lint-rule-style/readme.md
+++ b/packages/remark-lint-rule-style/readme.md
@@ -175,7 +175,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with [`settings.ruleSpaces: true`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulespaces).
+When [`settings.ruleSpaces`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulespaces) is `true` and the rule is not configured.
 
 ###### In
 
@@ -207,7 +207,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with [`settings.rule: '_'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrule), [`settings.ruleRepetition: 7`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulerepetition).
+When [`settings.rule`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrule) is `'_'`, [`settings.ruleRepetition`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulerepetition) is `7`, and the rule is not configured.
 
 ###### In
 

--- a/packages/remark-lint-rule-style/readme.md
+++ b/packages/remark-lint-rule-style/readme.md
@@ -46,7 +46,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'---'` |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | [`settings.rule`](https://github.com/remarkjs/remark-lint#configure) is `'-'` |
 
 ## Install
 
@@ -125,7 +125,7 @@ The default export is `remarkLintRuleStyle`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: [`settings.rule`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrule), [`settings.ruleRepetition`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulerepetition), [`settings.ruleSpaces`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulespaces), or `'consistent'`) are accepted:
+The following options (default: [`settings.rule`](https://github.com/remarkjs/remark-lint#configure), [`settings.ruleRepetition`](https://github.com/remarkjs/remark-lint#configure), [`settings.ruleSpaces`](https://github.com/remarkjs/remark-lint#configure), or `'consistent'`) are accepted:
 
 *   `string` (example: `'** * **'`, `'___'`)
     — thematic break to prefer
@@ -148,18 +148,18 @@ Due to this, it’s recommended to pass `'***'`.
 formats rules with `***` by default.
 There are three settings to control rules:
 
-*   [`rule`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrule)
+*   [`settings.rule`](https://github.com/remarkjs/remark-lint#configure)
     (default: `'*'`) — marker
-*   [`ruleRepetition`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulerepetition)
+*   [`settings.ruleRepetition`](https://github.com/remarkjs/remark-lint#configure)
     (default: `3`) — repetitions
-*   [`ruleSpaces`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulespaces)
+*   [`settings.ruleSpaces`](https://github.com/remarkjs/remark-lint#configure)
     (default: `false`) — use spaces between markers
 
 ## Examples
 
 ##### `ok.md`
 
-When configured with `'* * *'`.
+When [`settings.ruleSpaces`](https://github.com/remarkjs/remark-lint#configure) is `true` and the rule is not configured.
 
 ###### In
 
@@ -175,39 +175,7 @@ No messages.
 
 ##### `ok.md`
 
-When [`settings.ruleSpaces`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulespaces) is `true` and the rule is not configured.
-
-###### In
-
-```markdown
-* * *
-
-* * *
-```
-
-###### Out
-
-No messages.
-
-##### `ok.md`
-
-When configured with `'_______'`.
-
-###### In
-
-```markdown
-_______
-
-_______
-```
-
-###### Out
-
-No messages.
-
-##### `ok.md`
-
-When [`settings.rule`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrule) is `'_'`, [`settings.ruleRepetition`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulerepetition) is `7`, and the rule is not configured.
+When [`settings`](https://github.com/remarkjs/remark-lint#configure) includes `{ rule: '_', ruleRepetition: 7 }` and the rule is not configured.
 
 ###### In
 

--- a/packages/remark-lint-strong-marker/index.js
+++ b/packages/remark-lint-strong-marker/index.js
@@ -50,12 +50,12 @@
  *   __foo__ and __bar__.
  *
  * @example
- *   {"name": "ok.md", "config": "*"}
+ *   {"name": "ok.md", "settings": {"strong": "*"}}
  *
  *   **foo**.
  *
  * @example
- *   {"name": "ok.md", "config": "_"}
+ *   {"name": "ok.md", "settings": {"strong": "_"}}
  *
  *   __foo__.
  *
@@ -70,7 +70,7 @@
  *   1:13-1:20: Strong should use `*` as a marker
  *
  * @example
- *   {"name": "not-ok.md", "label": "output", "config": "💩", "positionless": true}
+ *   {"name": "not-ok.md", "label": "output", "settings": {"strong": "💩"}, "positionless": true}
  *
  *   1:1: Incorrect strong marker `💩`: use either `'consistent'`, `'*'`, or `'_'`
  */

--- a/packages/remark-lint-strong-marker/index.js
+++ b/packages/remark-lint-strong-marker/index.js
@@ -5,7 +5,7 @@
  *
  * ## API
  *
- * The following options (default: [`settings.strong`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsstrong) or `'consistent'`) are accepted:
+ * The following options (default: [`settings.strong`](https://github.com/remarkjs/remark-lint#configure) or `'consistent'`) are accepted:
  *
  * *   `'*'`
  *     — prefer asterisks
@@ -29,8 +29,8 @@
  *
  * [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
  * formats strong with asterisks by default.
- * Pass
- * [`strong: '_'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsstrong)
+ * Change
+ * [`settings.strong`](https://github.com/remarkjs/remark-lint#configure) to `'_'`
  * to always use underscores.
  *
  * @module strong-marker

--- a/packages/remark-lint-strong-marker/index.js
+++ b/packages/remark-lint-strong-marker/index.js
@@ -5,7 +5,7 @@
  *
  * ## API
  *
- * The following options (default: `'consistent'`) are accepted:
+ * The following options (default: [`settings.strong`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsstrong) or `'consistent'`) are accepted:
  *
  * *   `'*'`
  *     — prefer asterisks

--- a/packages/remark-lint-strong-marker/index.js
+++ b/packages/remark-lint-strong-marker/index.js
@@ -110,8 +110,9 @@ const remarkLintStrongMarker = lintRule(
     const value = String(file)
 
     if (!option) {
-      const {settings} = this.data()
-      option = (settings && settings.strong) || 'consistent'
+      /** @type {import('remark-stringify').Options} */
+      const settings = this.data().settings || {}
+      option = settings.strong || 'consistent'
     }
 
     if (option !== '*' && option !== '_' && option !== 'consistent') {

--- a/packages/remark-lint-strong-marker/index.js
+++ b/packages/remark-lint-strong-marker/index.js
@@ -91,8 +91,13 @@ const remarkLintStrongMarker = lintRule(
     url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-strong-marker#readme'
   },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
-  (tree, file, option = 'consistent') => {
+  function (tree, file, option) {
     const value = String(file)
+
+    if (!option) {
+      const {settings} = this.data()
+      option = (settings && settings.strong) || 'consistent'
+    }
 
     if (option !== '*' && option !== '_' && option !== 'consistent') {
       file.fail(

--- a/packages/remark-lint-strong-marker/index.js
+++ b/packages/remark-lint-strong-marker/index.js
@@ -50,9 +50,19 @@
  *   __foo__ and __bar__.
  *
  * @example
+ *   {"name": "ok.md", "config": "*"}
+ *
+ *   **foo**.
+ *
+ * @example
  *   {"name": "ok.md", "settings": {"strong": "*"}}
  *
  *   **foo**.
+ *
+ * @example
+ *   {"name": "ok.md", "config": "_"}
+ *
+ *   __foo__.
  *
  * @example
  *   {"name": "ok.md", "settings": {"strong": "_"}}
@@ -68,6 +78,11 @@
  *   {"name": "not-ok.md", "label": "output"}
  *
  *   1:13-1:20: Strong should use `*` as a marker
+ *
+ * @example
+ *   {"name": "not-ok.md", "label": "output", "config": "💩", "positionless": true}
+ *
+ *   1:1: Incorrect strong marker `💩`: use either `'consistent'`, `'*'`, or `'_'`
  *
  * @example
  *   {"name": "not-ok.md", "label": "output", "settings": {"strong": "💩"}, "positionless": true}

--- a/packages/remark-lint-strong-marker/readme.md
+++ b/packages/remark-lint-strong-marker/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'*'` |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | |
 
 ## Install
 

--- a/packages/remark-lint-strong-marker/readme.md
+++ b/packages/remark-lint-strong-marker/readme.md
@@ -194,7 +194,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with `'*'`.
+When configured with [`settings.strong: '*'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsstrong).
 
 ###### In
 
@@ -208,7 +208,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with `'_'`.
+When configured with [`settings.strong: '_'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsstrong).
 
 ###### In
 
@@ -222,7 +222,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'💩'`.
+When configured with [`settings.strong: '💩'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsstrong).
 
 ###### Out
 

--- a/packages/remark-lint-strong-marker/readme.md
+++ b/packages/remark-lint-strong-marker/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'*'` |
 
 ## Install
 

--- a/packages/remark-lint-strong-marker/readme.md
+++ b/packages/remark-lint-strong-marker/readme.md
@@ -208,7 +208,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with [`settings.strong: '*'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsstrong).
+When [`settings.strong`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsstrong) is `'*'` and the rule is not configured.
 
 ###### In
 
@@ -236,7 +236,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with [`settings.strong: '_'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsstrong).
+When [`settings.strong`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsstrong) is `'_'` and the rule is not configured.
 
 ###### In
 
@@ -260,7 +260,7 @@ When configured with `'💩'`.
 
 ##### `not-ok.md`
 
-When configured with [`settings.strong: '💩'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsstrong).
+When [`settings.strong`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsstrong) is `'💩'` and the rule is not configured.
 
 ###### Out
 

--- a/packages/remark-lint-strong-marker/readme.md
+++ b/packages/remark-lint-strong-marker/readme.md
@@ -124,7 +124,7 @@ The default export is `remarkLintStrongMarker`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: `'consistent'`) are accepted:
+The following options (default: [`settings.strong`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsstrong) or `'consistent'`) are accepted:
 
 *   `'*'`
     — prefer asterisks

--- a/packages/remark-lint-strong-marker/readme.md
+++ b/packages/remark-lint-strong-marker/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-consistent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-consistent) | `'consistent'` |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'*'` |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | [`settings.strong`](https://github.com/remarkjs/remark-lint#configure) is `'*'` |
 
 ## Install
 
@@ -124,7 +124,7 @@ The default export is `remarkLintStrongMarker`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: [`settings.strong`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsstrong) or `'consistent'`) are accepted:
+The following options (default: [`settings.strong`](https://github.com/remarkjs/remark-lint#configure) or `'consistent'`) are accepted:
 
 *   `'*'`
     — prefer asterisks
@@ -148,8 +148,8 @@ can be used for more constructs, it’s recommended to prefer asterisks.
 
 [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
 formats strong with asterisks by default.
-Pass
-[`strong: '_'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsstrong)
+Change
+[`settings.strong`](https://github.com/remarkjs/remark-lint#configure) to `'_'`
 to always use underscores.
 
 ## Examples
@@ -194,7 +194,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with `'*'`.
+When [`settings.strong`](https://github.com/remarkjs/remark-lint#configure) is `'*'` and the rule is not configured.
 
 ###### In
 
@@ -208,35 +208,7 @@ No messages.
 
 ##### `ok.md`
 
-When [`settings.strong`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsstrong) is `'*'` and the rule is not configured.
-
-###### In
-
-```markdown
-**foo**.
-```
-
-###### Out
-
-No messages.
-
-##### `ok.md`
-
-When configured with `'_'`.
-
-###### In
-
-```markdown
-__foo__.
-```
-
-###### Out
-
-No messages.
-
-##### `ok.md`
-
-When [`settings.strong`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsstrong) is `'_'` and the rule is not configured.
+When [`settings.strong`](https://github.com/remarkjs/remark-lint#configure) is `'_'` and the rule is not configured.
 
 ###### In
 
@@ -250,17 +222,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'💩'`.
-
-###### Out
-
-```text
-1:1: Incorrect strong marker `💩`: use either `'consistent'`, `'*'`, or `'_'`
-```
-
-##### `not-ok.md`
-
-When [`settings.strong`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsstrong) is `'💩'` and the rule is not configured.
+When [`settings.strong`](https://github.com/remarkjs/remark-lint#configure) is `'💩'` and the rule is not configured.
 
 ###### Out
 

--- a/packages/remark-lint-strong-marker/readme.md
+++ b/packages/remark-lint-strong-marker/readme.md
@@ -194,12 +194,40 @@ No messages.
 
 ##### `ok.md`
 
+When configured with `'*'`.
+
+###### In
+
+```markdown
+**foo**.
+```
+
+###### Out
+
+No messages.
+
+##### `ok.md`
+
 When configured with [`settings.strong: '*'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsstrong).
 
 ###### In
 
 ```markdown
 **foo**.
+```
+
+###### Out
+
+No messages.
+
+##### `ok.md`
+
+When configured with `'_'`.
+
+###### In
+
+```markdown
+__foo__.
 ```
 
 ###### Out
@@ -219,6 +247,16 @@ __foo__.
 ###### Out
 
 No messages.
+
+##### `not-ok.md`
+
+When configured with `'💩'`.
+
+###### Out
+
+```text
+1:1: Incorrect strong marker `💩`: use either `'consistent'`, `'*'`, or `'_'`
+```
 
 ##### `not-ok.md`
 

--- a/packages/remark-lint-unordered-list-marker-style/index.js
+++ b/packages/remark-lint-unordered-list-marker-style/index.js
@@ -54,14 +54,29 @@
  *   3. Baz
  *
  * @example
+ *   {"name": "ok.md", "config": "*"}
+ *
+ *   * Foo
+ *
+ * @example
  *   {"name": "ok.md", "settings": {"bullet": "*"}}
  *
  *   * Foo
  *
  * @example
+ *   {"name": "ok.md", "config": "-"}
+ *
+ *   - Foo
+ *
+ * @example
  *   {"name": "ok.md", "settings": {"bullet": "-"}}
  *
  *   - Foo
+ *
+ * @example
+ *   {"name": "ok.md", "config": "+"}
+ *
+ *   + Foo
  *
  * @example
  *   {"name": "ok.md", "settings": {"bullet": "+"}}
@@ -80,6 +95,11 @@
  *
  *   2:1-2:6: Marker style should be `*`
  *   3:1-3:6: Marker style should be `*`
+ *
+ * @example
+ *   {"name": "not-ok.md", "label": "output", "config": "💩", "positionless": true}
+ *
+ *   1:1: Incorrect unordered list item marker style `💩`: use either `'-'`, `'*'`, or `'+'`
  *
  * @example
  *   {"name": "not-ok.md", "label": "output", "settings": {"bullet": "💩"}, "positionless": true}

--- a/packages/remark-lint-unordered-list-marker-style/index.js
+++ b/packages/remark-lint-unordered-list-marker-style/index.js
@@ -6,7 +6,7 @@
  *
  * ## API
  *
- * The following options (default: [`settings.bullet`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet) or `'consistent'`) are accepted:
+ * The following options (default: [`settings.bullet`](https://github.com/remarkjs/remark-lint#configure) or `'consistent'`) are accepted:
  *
  * *   `'*'`
  *     — prefer asterisks
@@ -27,8 +27,8 @@
  *
  * [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
  * formats ordered lists with asterisks by default.
- * Pass
- * [`bullet: '+'` or `bullet: '-'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet)
+ * Change
+ * [`settings.bullet`](https://github.com/remarkjs/remark-lint#configure) to `'+'` or `'-'`
  * to always use plusses or dashes.
  *
  * @module unordered-list-marker-style

--- a/packages/remark-lint-unordered-list-marker-style/index.js
+++ b/packages/remark-lint-unordered-list-marker-style/index.js
@@ -130,8 +130,9 @@ const remarkLintUnorderedListMarkerStyle = lintRule(
     const value = String(file)
 
     if (!option) {
-      const {settings} = this.data()
-      option = (settings && settings.bullet) || 'consistent'
+      /** @type {import('remark-stringify').Options} */
+      const settings = this.data().settings || {}
+      option = settings.bullet || 'consistent'
     }
 
     if (option !== 'consistent' && !markers.has(option)) {

--- a/packages/remark-lint-unordered-list-marker-style/index.js
+++ b/packages/remark-lint-unordered-list-marker-style/index.js
@@ -6,7 +6,7 @@
  *
  * ## API
  *
- * The following options (default: `'consistent'`) are accepted:
+ * The following options (default: [`settings.bullet`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet) or `'consistent'`) are accepted:
  *
  * *   `'*'`
  *     — prefer asterisks
@@ -54,17 +54,17 @@
  *   3. Baz
  *
  * @example
- *   {"name": "ok.md", "config": "*"}
+ *   {"name": "ok.md", "settings": {"bullet": "*"}}
  *
  *   * Foo
  *
  * @example
- *   {"name": "ok.md", "config": "-"}
+ *   {"name": "ok.md", "settings": {"bullet": "-"}}
  *
  *   - Foo
  *
  * @example
- *   {"name": "ok.md", "config": "+"}
+ *   {"name": "ok.md", "settings": {"bullet": "+"}}
  *
  *   + Foo
  *
@@ -82,7 +82,7 @@
  *   3:1-3:6: Marker style should be `*`
  *
  * @example
- *   {"name": "not-ok.md", "label": "output", "config": "💩", "positionless": true}
+ *   {"name": "not-ok.md", "label": "output", "settings": {"bullet": "💩"}, "positionless": true}
  *
  *   1:1: Incorrect unordered list item marker style `💩`: use either `'-'`, `'*'`, or `'+'`
  */
@@ -106,8 +106,13 @@ const remarkLintUnorderedListMarkerStyle = lintRule(
     url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-unordered-list-marker-style#readme'
   },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
-  (tree, file, option = 'consistent') => {
+  function (tree, file, option) {
     const value = String(file)
+
+    if (!option) {
+      const {settings} = this.data()
+      option = (settings && settings.bullet) || 'consistent'
+    }
 
     if (option !== 'consistent' && !markers.has(option)) {
       file.fail(

--- a/packages/remark-lint-unordered-list-marker-style/readme.md
+++ b/packages/remark-lint-unordered-list-marker-style/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 
 | Preset | Setting |
 | - | - |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'-'` |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | |
 
 ## Install
 

--- a/packages/remark-lint-unordered-list-marker-style/readme.md
+++ b/packages/remark-lint-unordered-list-marker-style/readme.md
@@ -124,7 +124,7 @@ The default export is `remarkLintUnorderedListMarkerStyle`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: `'consistent'`) are accepted:
+The following options (default: [`settings.bullet`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet) or `'consistent'`) are accepted:
 
 *   `'*'`
     — prefer asterisks
@@ -193,7 +193,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with `'*'`.
+When configured with [`settings.bullet: '*'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet).
 
 ###### In
 
@@ -207,7 +207,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with `'-'`.
+When configured with [`settings.bullet: '-'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet).
 
 ###### In
 
@@ -221,7 +221,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with `'+'`.
+When configured with [`settings.bullet: '+'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet).
 
 ###### In
 
@@ -235,7 +235,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'💩'`.
+When configured with [`settings.bullet: '💩'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet).
 
 ###### Out
 

--- a/packages/remark-lint-unordered-list-marker-style/readme.md
+++ b/packages/remark-lint-unordered-list-marker-style/readme.md
@@ -207,7 +207,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with [`settings.bullet: '*'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet).
+When [`settings.bullet`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet) is `'*'` and the rule is not configured.
 
 ###### In
 
@@ -235,7 +235,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with [`settings.bullet: '-'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet).
+When [`settings.bullet`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet) is `'-'` and the rule is not configured.
 
 ###### In
 
@@ -263,7 +263,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with [`settings.bullet: '+'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet).
+When [`settings.bullet`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet) is `'+'` and the rule is not configured.
 
 ###### In
 
@@ -287,7 +287,7 @@ When configured with `'💩'`.
 
 ##### `not-ok.md`
 
-When configured with [`settings.bullet: '💩'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet).
+When [`settings.bullet`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet) is `'💩'` and the rule is not configured.
 
 ###### Out
 

--- a/packages/remark-lint-unordered-list-marker-style/readme.md
+++ b/packages/remark-lint-unordered-list-marker-style/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 
 | Preset | Setting |
 | - | - |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'-'` |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | [`settings.bullet`](https://github.com/remarkjs/remark-lint#configure) is `'-'` |
 
 ## Install
 
@@ -124,7 +124,7 @@ The default export is `remarkLintUnorderedListMarkerStyle`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: [`settings.bullet`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet) or `'consistent'`) are accepted:
+The following options (default: [`settings.bullet`](https://github.com/remarkjs/remark-lint#configure) or `'consistent'`) are accepted:
 
 *   `'*'`
     — prefer asterisks
@@ -145,8 +145,8 @@ strong) too.
 
 [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
 formats ordered lists with asterisks by default.
-Pass
-[`bullet: '+'` or `bullet: '-'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet)
+Change
+[`settings.bullet`](https://github.com/remarkjs/remark-lint#configure) to `'+'` or `'-'`
 to always use plusses or dashes.
 
 ## Examples
@@ -193,7 +193,7 @@ No messages.
 
 ##### `ok.md`
 
-When configured with `'*'`.
+When [`settings.bullet`](https://github.com/remarkjs/remark-lint#configure) is `'*'` and the rule is not configured.
 
 ###### In
 
@@ -207,21 +207,7 @@ No messages.
 
 ##### `ok.md`
 
-When [`settings.bullet`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet) is `'*'` and the rule is not configured.
-
-###### In
-
-```markdown
-* Foo
-```
-
-###### Out
-
-No messages.
-
-##### `ok.md`
-
-When configured with `'-'`.
+When [`settings.bullet`](https://github.com/remarkjs/remark-lint#configure) is `'-'` and the rule is not configured.
 
 ###### In
 
@@ -235,35 +221,7 @@ No messages.
 
 ##### `ok.md`
 
-When [`settings.bullet`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet) is `'-'` and the rule is not configured.
-
-###### In
-
-```markdown
-- Foo
-```
-
-###### Out
-
-No messages.
-
-##### `ok.md`
-
-When configured with `'+'`.
-
-###### In
-
-```markdown
-+ Foo
-```
-
-###### Out
-
-No messages.
-
-##### `ok.md`
-
-When [`settings.bullet`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet) is `'+'` and the rule is not configured.
+When [`settings.bullet`](https://github.com/remarkjs/remark-lint#configure) is `'+'` and the rule is not configured.
 
 ###### In
 
@@ -277,17 +235,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'💩'`.
-
-###### Out
-
-```text
-1:1: Incorrect unordered list item marker style `💩`: use either `'-'`, `'*'`, or `'+'`
-```
-
-##### `not-ok.md`
-
-When [`settings.bullet`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet) is `'💩'` and the rule is not configured.
+When [`settings.bullet`](https://github.com/remarkjs/remark-lint#configure) is `'💩'` and the rule is not configured.
 
 ###### Out
 

--- a/packages/remark-lint-unordered-list-marker-style/readme.md
+++ b/packages/remark-lint-unordered-list-marker-style/readme.md
@@ -45,7 +45,7 @@ This rule is included in the following presets:
 
 | Preset | Setting |
 | - | - |
-| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | |
+| [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'-'` |
 
 ## Install
 

--- a/packages/remark-lint-unordered-list-marker-style/readme.md
+++ b/packages/remark-lint-unordered-list-marker-style/readme.md
@@ -193,12 +193,40 @@ No messages.
 
 ##### `ok.md`
 
+When configured with `'*'`.
+
+###### In
+
+```markdown
+* Foo
+```
+
+###### Out
+
+No messages.
+
+##### `ok.md`
+
 When configured with [`settings.bullet: '*'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet).
 
 ###### In
 
 ```markdown
 * Foo
+```
+
+###### Out
+
+No messages.
+
+##### `ok.md`
+
+When configured with `'-'`.
+
+###### In
+
+```markdown
+- Foo
 ```
 
 ###### Out
@@ -221,6 +249,20 @@ No messages.
 
 ##### `ok.md`
 
+When configured with `'+'`.
+
+###### In
+
+```markdown
++ Foo
+```
+
+###### Out
+
+No messages.
+
+##### `ok.md`
+
 When configured with [`settings.bullet: '+'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet).
 
 ###### In
@@ -232,6 +274,16 @@ When configured with [`settings.bullet: '+'`](https://github.com/remarkjs/remark
 ###### Out
 
 No messages.
+
+##### `not-ok.md`
+
+When configured with `'💩'`.
+
+###### Out
+
+```text
+1:1: Incorrect unordered list item marker style `💩`: use either `'-'`, `'*'`, or `'+'`
+```
 
 ##### `not-ok.md`
 

--- a/packages/remark-preset-lint-consistent/readme.md
+++ b/packages/remark-preset-lint-consistent/readme.md
@@ -17,6 +17,7 @@ Preset of [`remark-lint`][mono] rules to warn for inconsistencies.
 *   [What is this?](#what-is-this)
 *   [When should I use this?](#when-should-i-use-this)
 *   [Rules](#rules)
+*   [Settings](#settings)
 *   [Install](#install)
 *   [Use](#use)
 *   [API](#api)
@@ -53,6 +54,10 @@ This preset configures [`remark-lint`][mono] with the following rules:
 | [`remark-lint-rule-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-rule-style) | `'consistent'` |
 | [`remark-lint-strong-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-strong-marker) | `'consistent'` |
 | [`remark-lint-table-cell-padding`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-table-cell-padding) | `'consistent'` |
+
+## Settings
+
+It doesn't set any remark [settings][configure].
 
 ## Install
 
@@ -182,6 +187,8 @@ abide by its terms.
 [remark]: https://github.com/remarkjs/remark
 
 [mono]: https://github.com/remarkjs/remark-lint
+
+[configure]: https://github.com/remarkjs/remark-lint#configure
 
 [esm]: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
 

--- a/packages/remark-preset-lint-markdown-style-guide/index.js
+++ b/packages/remark-preset-lint-markdown-style-guide/index.js
@@ -285,7 +285,20 @@ const remarkPresetLintMarkdownStyleGuide = {
 
     // https://cirosantilli.com/markdown-style-guide/#email-automatic-links.
     // Not checked.
-  ]
+  ],
+  settings: {
+    bullet: '-',
+    bulletOrdered: '.',
+    emphasis: '*',
+    fence: '`',
+    fences: true,
+    incrementListMarker: false,
+    listItemIndent: 'mixed',
+    quote: '"',
+    rule: '-',
+    setext: false,
+    strong: '*'
+  }
 }
 
 export default remarkPresetLintMarkdownStyleGuide

--- a/packages/remark-preset-lint-markdown-style-guide/index.js
+++ b/packages/remark-preset-lint-markdown-style-guide/index.js
@@ -36,7 +36,7 @@
  * ###### `header`
  *
  * The default is `header:atx`.
- * To use `header:setext`, change the setting for `remark-lint-heading-style`
+ * To use `header:setext`, change [`settings.setext`](https://github.com/remarkjs/remark-lint#configure)
  * like so:
  *
  * ```diff
@@ -50,8 +50,8 @@
  * ###### `list-marker`
  *
  * The default is `list-marker:hyphen`.
- * For `list-marker:asterisk` or `list-marker:plus`, change the setting for
- * `remark-lint-unordered-list-marker-style` like so:
+ * For `list-marker:asterisk` or `list-marker:plus`, change [`settings.bullet`](https://github.com/remarkjs/remark-lint#configure)
+ * like so:
  *
  * ```diff
  *  "settings": [
@@ -64,7 +64,7 @@
  * ###### `list-space`
  *
  * The default is `list-space:mixed`.
- * For `list-space:1`, change the setting for `remark-lint-list-item-indent`
+ * For `list-space:1`, change [`settings.listItemIndent`](https://github.com/remarkjs/remark-lint#configure)
  * like so:
  *
  * ```diff
@@ -78,7 +78,7 @@
  * ###### `code`
  *
  * The default is `code:fenced`.
- * For `code:indented`, change the setting for `remark-lint-code-block-style`
+ * For `code:indented`, change [`settings.fences`](https://github.com/remarkjs/remark-lint#configure)
  * like so:
  *
  * ```diff

--- a/packages/remark-preset-lint-markdown-style-guide/index.js
+++ b/packages/remark-preset-lint-markdown-style-guide/index.js
@@ -40,10 +40,9 @@
  * like so:
  *
  * ```diff
- *  "plugins": [
+ *  "settings": [
  *    …
- *    "remark-preset-lint-markdown-style-guide",
- * +  ["remark-lint-heading-style", "setext"],
+ * +  "setext": true,
  *    …
  *  ]
  * ```
@@ -55,10 +54,9 @@
  * `remark-lint-unordered-list-marker-style` like so:
  *
  * ```diff
- *  "plugins": [
+ *  "settings": [
  *    …
- *    "remark-preset-lint-markdown-style-guide",
- * +  ["remark-lint-unordered-list-marker-style", "*"],
+ * +  "bullet": "*",
  *    …
  *  ]
  * ```
@@ -70,10 +68,9 @@
  * like so:
  *
  * ```diff
- *  "plugins": [
+ *  "settings": [
  *    …
- *    "remark-preset-lint-markdown-style-guide",
- * +  ["remark-lint-list-item-indent", "one"],
+ * +  "listItemIndent": "one",
  *    …
  *  ]
  * ```
@@ -85,10 +82,9 @@
  * like so:
  *
  * ```diff
- *  "plugins": [
+ *  "settings": [
  *    …
- *    "remark-preset-lint-markdown-style-guide",
- * +  ["remark-lint-code-block-style", "indented"],
+ * +  "fences": false,
  *    …
  *  ]
  * ```
@@ -187,7 +183,7 @@ const remarkPresetLintMarkdownStyleGuide = {
     remarkLintHardBreakSpaces,
 
     // https://cirosantilli.com/markdown-style-guide/#headers
-    [remarkLintHeadingStyle, 'atx'],
+    remarkLintHeadingStyle,
     remarkLintHeadingIncrement,
     remarkLintNoDuplicateHeadings,
 
@@ -214,14 +210,14 @@ const remarkPresetLintMarkdownStyleGuide = {
     remarkLintNoBlockquoteWithoutMarker,
 
     // https://cirosantilli.com/markdown-style-guide/#unordered
-    [remarkLintUnorderedListMarkerStyle, '-'],
+    remarkLintUnorderedListMarkerStyle,
 
     // https://cirosantilli.com/markdown-style-guide/#ordered
-    [remarkLintOrderedListMarkerStyle, '.'],
+    remarkLintOrderedListMarkerStyle,
     [remarkLintOrderedListMarkerValue, 'one'],
 
     // https://cirosantilli.com/markdown-style-guide/#spaces-after-list-marker
-    [remarkLintListItemIndent, 'mixed'],
+    remarkLintListItemIndent,
 
     // https://cirosantilli.com/markdown-style-guide/#indentation-of-content-inside-lists
     remarkLintListItemContentIndent,
@@ -239,12 +235,12 @@ const remarkPresetLintMarkdownStyleGuide = {
     // Not checked.
 
     // https://cirosantilli.com/markdown-style-guide/#code-blocks
-    [remarkLintCodeBlockStyle, 'fenced'],
+    remarkLintCodeBlockStyle,
     [remarkLintFencedCodeFlag, {allowEmpty: false}],
-    [remarkLintFencedCodeMarker, '`'],
+    remarkLintFencedCodeMarker,
 
     // https://cirosantilli.com/markdown-style-guide/#horizontal-rules
-    [remarkLintRuleStyle, '---'],
+    remarkLintRuleStyle,
 
     // https://cirosantilli.com/markdown-style-guide/#tables
     remarkLintNoTableIndentation,
@@ -266,13 +262,13 @@ const remarkPresetLintMarkdownStyleGuide = {
     remarkLintDefinitionSpacing,
 
     // https://cirosantilli.com/markdown-style-guide/#single-or-double-quote-titles
-    [remarkLintLinkTitleStyle, '"'],
+    remarkLintLinkTitleStyle,
 
     // https://cirosantilli.com/markdown-style-guide/#bold
-    [remarkLintStrongMarker, '*'],
+    remarkLintStrongMarker,
 
     // https://cirosantilli.com/markdown-style-guide/#italic
-    [remarkLintEmphasisMarker, '*'],
+    remarkLintEmphasisMarker,
 
     // https://cirosantilli.com/markdown-style-guide/#uppercase-for-emphasis.
     // Not checked.

--- a/packages/remark-preset-lint-markdown-style-guide/index.js
+++ b/packages/remark-preset-lint-markdown-style-guide/index.js
@@ -73,7 +73,7 @@
  *  "plugins": [
  *    …
  *    "remark-preset-lint-markdown-style-guide",
- * +  ["remark-lint-list-item-indent", "space"],
+ * +  ["remark-lint-list-item-indent", "one"],
  *    …
  *  ]
  * ```

--- a/packages/remark-preset-lint-markdown-style-guide/readme.md
+++ b/packages/remark-preset-lint-markdown-style-guide/readme.md
@@ -69,7 +69,7 @@ To use `wrap:no`, turn off `remark-lint-maximum-line-length` like so:
 ###### `header`
 
 The default is `header:atx`.
-To use `header:setext`, change the setting for `remark-lint-heading-style`
+To use `header:setext`, change [`settings.setext`](https://github.com/remarkjs/remark-lint#configure)
 like so:
 
 ```diff
@@ -83,8 +83,8 @@ like so:
 ###### `list-marker`
 
 The default is `list-marker:hyphen`.
-For `list-marker:asterisk` or `list-marker:plus`, change the setting for
-`remark-lint-unordered-list-marker-style` like so:
+For `list-marker:asterisk` or `list-marker:plus`, change [`settings.bullet`](https://github.com/remarkjs/remark-lint#configure)
+like so:
 
 ```diff
  "settings": [
@@ -97,7 +97,7 @@ For `list-marker:asterisk` or `list-marker:plus`, change the setting for
 ###### `list-space`
 
 The default is `list-space:mixed`.
-For `list-space:1`, change the setting for `remark-lint-list-item-indent`
+For `list-space:1`, change [`settings.listItemIndent`](https://github.com/remarkjs/remark-lint#configure)
 like so:
 
 ```diff
@@ -111,7 +111,7 @@ like so:
 ###### `code`
 
 The default is `code:fenced`.
-For `code:indented`, change the setting for `remark-lint-code-block-style`
+For `code:indented`, change [`settings.fences`](https://github.com/remarkjs/remark-lint#configure)
 like so:
 
 ```diff
@@ -138,7 +138,7 @@ This preset configures [`remark-lint`][mono] with the following rules:
 | [`remark-lint-maximum-line-length`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-maximum-line-length) | `80` |
 | [`remark-lint-no-shell-dollars`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-shell-dollars) | |
 | [`remark-lint-hard-break-spaces`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-hard-break-spaces) | |
-| [`remark-lint-heading-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-heading-style) | `'atx'` |
+| [`remark-lint-heading-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-heading-style) | [`settings.setext`](https://github.com/remarkjs/remark-lint#configure) is `false` |
 | [`remark-lint-heading-increment`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-heading-increment) | |
 | [`remark-lint-no-duplicate-headings`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-duplicate-headings) | |
 | [`remark-lint-no-multiple-toplevel-headings`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-multiple-toplevel-headings) | |
@@ -146,16 +146,16 @@ This preset configures [`remark-lint`][mono] with the following rules:
 | [`remark-lint-no-heading-punctuation`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-heading-punctuation) | `':.'` |
 | [`remark-lint-blockquote-indentation`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-blockquote-indentation) | `2` |
 | [`remark-lint-no-blockquote-without-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-blockquote-without-marker) | |
-| [`remark-lint-unordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-unordered-list-marker-style) | `'-'` |
-| [`remark-lint-ordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-style) | `'.'` |
+| [`remark-lint-unordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-unordered-list-marker-style) | [`settings.bullet`](https://github.com/remarkjs/remark-lint#configure) is `'-'` |
+| [`remark-lint-ordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-style) | [`settings.bulletOrdered`](https://github.com/remarkjs/remark-lint#configure) is `'.'` |
 | [`remark-lint-ordered-list-marker-value`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-value) | `'one'` |
-| [`remark-lint-list-item-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent) | `'mixed'` |
+| [`remark-lint-list-item-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent) | [`settings.listItemIndent`](https://github.com/remarkjs/remark-lint#configure) is `'mixed'` |
 | [`remark-lint-list-item-content-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-content-indent) | |
 | [`remark-lint-list-item-spacing`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-spacing) | |
-| [`remark-lint-code-block-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-code-block-style) | `'fenced'` |
+| [`remark-lint-code-block-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-code-block-style) | [`settings.fences`](https://github.com/remarkjs/remark-lint#configure) is `true` |
 | [`remark-lint-fenced-code-flag`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-fenced-code-flag) | `{ allowEmpty: false }` |
-| [`remark-lint-fenced-code-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-fenced-code-marker) | ``'`'`` |
-| [`remark-lint-rule-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-rule-style) | `'---'` |
+| [`remark-lint-fenced-code-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-fenced-code-marker) | [`settings.fence`](https://github.com/remarkjs/remark-lint#configure) is ``'`'`` |
+| [`remark-lint-rule-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-rule-style) | [`settings.rule`](https://github.com/remarkjs/remark-lint#configure) is `'-'` |
 | [`remark-lint-no-table-indentation`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-table-indentation) | |
 | [`remark-lint-table-pipes`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-table-pipes) | |
 | [`remark-lint-table-pipe-alignment`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-table-pipe-alignment) | |
@@ -166,9 +166,9 @@ This preset configures [`remark-lint`][mono] with the following rules:
 | [`remark-lint-final-definition`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-final-definition) | |
 | [`remark-lint-definition-case`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-definition-case) | |
 | [`remark-lint-definition-spacing`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-definition-spacing) | |
-| [`remark-lint-link-title-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-link-title-style) | `'"'` |
-| [`remark-lint-strong-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-strong-marker) | `'*'` |
-| [`remark-lint-emphasis-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-emphasis-marker) | `'*'` |
+| [`remark-lint-link-title-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-link-title-style) | [`settings.quote`](https://github.com/remarkjs/remark-lint#configure) is `'"'` |
+| [`remark-lint-strong-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-strong-marker) | [`settings.strong`](https://github.com/remarkjs/remark-lint#configure) is `'*'` |
+| [`remark-lint-emphasis-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-emphasis-marker) | [`settings.emphasis`](https://github.com/remarkjs/remark-lint#configure) is `'*'` |
 | [`remark-lint-no-emphasis-as-heading`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-emphasis-as-heading) | |
 | [`remark-lint-no-literal-urls`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-literal-urls) | |
 

--- a/packages/remark-preset-lint-markdown-style-guide/readme.md
+++ b/packages/remark-preset-lint-markdown-style-guide/readme.md
@@ -73,10 +73,9 @@ To use `header:setext`, change the setting for `remark-lint-heading-style`
 like so:
 
 ```diff
- "plugins": [
+ "settings": [
    …
-   "remark-preset-lint-markdown-style-guide",
-+  ["remark-lint-heading-style", "setext"],
++  "setext": true,
    …
  ]
 ```
@@ -88,10 +87,9 @@ For `list-marker:asterisk` or `list-marker:plus`, change the setting for
 `remark-lint-unordered-list-marker-style` like so:
 
 ```diff
- "plugins": [
+ "settings": [
    …
-   "remark-preset-lint-markdown-style-guide",
-+  ["remark-lint-unordered-list-marker-style", "*"],
++  "bullet": "*",
    …
  ]
 ```
@@ -103,10 +101,9 @@ For `list-space:1`, change the setting for `remark-lint-list-item-indent`
 like so:
 
 ```diff
- "plugins": [
+ "settings": [
    …
-   "remark-preset-lint-markdown-style-guide",
-+  ["remark-lint-list-item-indent", "one"],
++  "listItemIndent": "one",
    …
  ]
 ```
@@ -118,10 +115,9 @@ For `code:indented`, change the setting for `remark-lint-code-block-style`
 like so:
 
 ```diff
- "plugins": [
+ "settings": [
    …
-   "remark-preset-lint-markdown-style-guide",
-+  ["remark-lint-code-block-style", "indented"],
++  "fences": false,
    …
  ]
 ```
@@ -142,7 +138,7 @@ This preset configures [`remark-lint`][mono] with the following rules:
 | [`remark-lint-maximum-line-length`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-maximum-line-length) | `80` |
 | [`remark-lint-no-shell-dollars`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-shell-dollars) | |
 | [`remark-lint-hard-break-spaces`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-hard-break-spaces) | |
-| [`remark-lint-heading-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-heading-style) | `'atx'` |
+| [`remark-lint-heading-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-heading-style) | |
 | [`remark-lint-heading-increment`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-heading-increment) | |
 | [`remark-lint-no-duplicate-headings`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-duplicate-headings) | |
 | [`remark-lint-no-multiple-toplevel-headings`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-multiple-toplevel-headings) | |
@@ -150,16 +146,16 @@ This preset configures [`remark-lint`][mono] with the following rules:
 | [`remark-lint-no-heading-punctuation`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-heading-punctuation) | `':.'` |
 | [`remark-lint-blockquote-indentation`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-blockquote-indentation) | `2` |
 | [`remark-lint-no-blockquote-without-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-blockquote-without-marker) | |
-| [`remark-lint-unordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-unordered-list-marker-style) | `'-'` |
-| [`remark-lint-ordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-style) | `'.'` |
+| [`remark-lint-unordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-unordered-list-marker-style) | |
+| [`remark-lint-ordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-style) | |
 | [`remark-lint-ordered-list-marker-value`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-value) | `'one'` |
-| [`remark-lint-list-item-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent) | `'mixed'` |
+| [`remark-lint-list-item-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent) | |
 | [`remark-lint-list-item-content-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-content-indent) | |
 | [`remark-lint-list-item-spacing`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-spacing) | |
-| [`remark-lint-code-block-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-code-block-style) | `'fenced'` |
+| [`remark-lint-code-block-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-code-block-style) | |
 | [`remark-lint-fenced-code-flag`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-fenced-code-flag) | `{ allowEmpty: false }` |
-| [`remark-lint-fenced-code-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-fenced-code-marker) | ``'`'`` |
-| [`remark-lint-rule-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-rule-style) | `'---'` |
+| [`remark-lint-fenced-code-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-fenced-code-marker) | |
+| [`remark-lint-rule-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-rule-style) | |
 | [`remark-lint-no-table-indentation`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-table-indentation) | |
 | [`remark-lint-table-pipes`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-table-pipes) | |
 | [`remark-lint-table-pipe-alignment`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-table-pipe-alignment) | |
@@ -170,9 +166,9 @@ This preset configures [`remark-lint`][mono] with the following rules:
 | [`remark-lint-final-definition`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-final-definition) | |
 | [`remark-lint-definition-case`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-definition-case) | |
 | [`remark-lint-definition-spacing`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-definition-spacing) | |
-| [`remark-lint-link-title-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-link-title-style) | `'"'` |
-| [`remark-lint-strong-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-strong-marker) | `'*'` |
-| [`remark-lint-emphasis-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-emphasis-marker) | `'*'` |
+| [`remark-lint-link-title-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-link-title-style) | |
+| [`remark-lint-strong-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-strong-marker) | |
+| [`remark-lint-emphasis-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-emphasis-marker) | |
 | [`remark-lint-no-emphasis-as-heading`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-emphasis-as-heading) | |
 | [`remark-lint-no-literal-urls`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-literal-urls) | |
 

--- a/packages/remark-preset-lint-markdown-style-guide/readme.md
+++ b/packages/remark-preset-lint-markdown-style-guide/readme.md
@@ -17,6 +17,7 @@ Preset of [`remark-lint`][mono] rules that follow an opinionated style guide.
 *   [What is this?](#what-is-this)
 *   [When should I use this?](#when-should-i-use-this)
 *   [Rules](#rules)
+*   [Settings](#settings)
 *   [Install](#install)
 *   [Use](#use)
 *   [API](#api)
@@ -175,6 +176,25 @@ This preset configures [`remark-lint`][mono] with the following rules:
 | [`remark-lint-no-emphasis-as-heading`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-emphasis-as-heading) | |
 | [`remark-lint-no-literal-urls`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-literal-urls) | |
 
+## Settings
+
+It sets the following remark [settings][configure].
+Settings are shared among all plugins --- particularly the corresponding rules and [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#options):
+
+| Name | Value |
+| - | - |
+| `settings.bullet` | `'-'` |
+| `settings.bulletOrdered` | `'.'` |
+| `settings.emphasis` | `'*'` |
+| `settings.fence` | ``'`'`` |
+| `settings.fences` | `true` |
+| `settings.incrementListMarker` | `false` |
+| `settings.listItemIndent` | `'mixed'` |
+| `settings.quote` | `'"'` |
+| `settings.rule` | `'-'` |
+| `settings.setext` | `false` |
+| `settings.strong` | `'*'` |
+
 ## Install
 
 This package is [ESM only][esm].
@@ -303,6 +323,8 @@ abide by its terms.
 [remark]: https://github.com/remarkjs/remark
 
 [mono]: https://github.com/remarkjs/remark-lint
+
+[configure]: https://github.com/remarkjs/remark-lint#configure
 
 [esm]: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
 

--- a/packages/remark-preset-lint-markdown-style-guide/readme.md
+++ b/packages/remark-preset-lint-markdown-style-guide/readme.md
@@ -138,7 +138,7 @@ This preset configures [`remark-lint`][mono] with the following rules:
 | [`remark-lint-maximum-line-length`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-maximum-line-length) | `80` |
 | [`remark-lint-no-shell-dollars`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-shell-dollars) | |
 | [`remark-lint-hard-break-spaces`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-hard-break-spaces) | |
-| [`remark-lint-heading-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-heading-style) | |
+| [`remark-lint-heading-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-heading-style) | `'atx'` |
 | [`remark-lint-heading-increment`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-heading-increment) | |
 | [`remark-lint-no-duplicate-headings`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-duplicate-headings) | |
 | [`remark-lint-no-multiple-toplevel-headings`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-multiple-toplevel-headings) | |
@@ -146,16 +146,16 @@ This preset configures [`remark-lint`][mono] with the following rules:
 | [`remark-lint-no-heading-punctuation`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-heading-punctuation) | `':.'` |
 | [`remark-lint-blockquote-indentation`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-blockquote-indentation) | `2` |
 | [`remark-lint-no-blockquote-without-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-blockquote-without-marker) | |
-| [`remark-lint-unordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-unordered-list-marker-style) | |
-| [`remark-lint-ordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-style) | |
+| [`remark-lint-unordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-unordered-list-marker-style) | `'-'` |
+| [`remark-lint-ordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-style) | `'.'` |
 | [`remark-lint-ordered-list-marker-value`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-value) | `'one'` |
-| [`remark-lint-list-item-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent) | |
+| [`remark-lint-list-item-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent) | `'mixed'` |
 | [`remark-lint-list-item-content-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-content-indent) | |
 | [`remark-lint-list-item-spacing`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-spacing) | |
-| [`remark-lint-code-block-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-code-block-style) | |
+| [`remark-lint-code-block-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-code-block-style) | `'fenced'` |
 | [`remark-lint-fenced-code-flag`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-fenced-code-flag) | `{ allowEmpty: false }` |
-| [`remark-lint-fenced-code-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-fenced-code-marker) | |
-| [`remark-lint-rule-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-rule-style) | |
+| [`remark-lint-fenced-code-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-fenced-code-marker) | ``'`'`` |
+| [`remark-lint-rule-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-rule-style) | `'---'` |
 | [`remark-lint-no-table-indentation`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-table-indentation) | |
 | [`remark-lint-table-pipes`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-table-pipes) | |
 | [`remark-lint-table-pipe-alignment`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-table-pipe-alignment) | |
@@ -166,9 +166,9 @@ This preset configures [`remark-lint`][mono] with the following rules:
 | [`remark-lint-final-definition`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-final-definition) | |
 | [`remark-lint-definition-case`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-definition-case) | |
 | [`remark-lint-definition-spacing`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-definition-spacing) | |
-| [`remark-lint-link-title-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-link-title-style) | |
-| [`remark-lint-strong-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-strong-marker) | |
-| [`remark-lint-emphasis-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-emphasis-marker) | |
+| [`remark-lint-link-title-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-link-title-style) | `'"'` |
+| [`remark-lint-strong-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-strong-marker) | `'*'` |
+| [`remark-lint-emphasis-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-emphasis-marker) | `'*'` |
 | [`remark-lint-no-emphasis-as-heading`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-emphasis-as-heading) | |
 | [`remark-lint-no-literal-urls`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-literal-urls) | |
 

--- a/packages/remark-preset-lint-markdown-style-guide/readme.md
+++ b/packages/remark-preset-lint-markdown-style-guide/readme.md
@@ -105,7 +105,7 @@ like so:
  "plugins": [
    …
    "remark-preset-lint-markdown-style-guide",
-+  ["remark-lint-list-item-indent", "space"],
++  ["remark-lint-list-item-indent", "one"],
    …
  ]
 ```

--- a/packages/remark-preset-lint-recommended/index.js
+++ b/packages/remark-preset-lint-recommended/index.js
@@ -35,10 +35,10 @@ const remarkPresetLintRecommended = {
     remarkLintFinalNewline,
     // Rendering across vendors differs greatly if using other styles.
     remarkLintListItemBulletIndent,
-    [remarkLintListItemIndent, 'tab'],
+    remarkLintListItemIndent,
     remarkLintNoBlockquoteWithoutMarker,
     remarkLintNoLiteralUrls,
-    [remarkLintOrderedListMarkerStyle, '.'],
+    remarkLintOrderedListMarkerStyle,
     // Mistakes.
     remarkLintHardBreakSpaces,
     remarkLintNoDuplicateDefinitions,

--- a/packages/remark-preset-lint-recommended/index.js
+++ b/packages/remark-preset-lint-recommended/index.js
@@ -35,7 +35,7 @@ const remarkPresetLintRecommended = {
     remarkLintFinalNewline,
     // Rendering across vendors differs greatly if using other styles.
     remarkLintListItemBulletIndent,
-    [remarkLintListItemIndent, 'tab-size'],
+    [remarkLintListItemIndent, 'tab'],
     remarkLintNoBlockquoteWithoutMarker,
     remarkLintNoLiteralUrls,
     [remarkLintOrderedListMarkerStyle, '.'],

--- a/packages/remark-preset-lint-recommended/index.js
+++ b/packages/remark-preset-lint-recommended/index.js
@@ -48,7 +48,11 @@ const remarkPresetLintRecommended = {
     remarkLintNoShortcutReferenceLink,
     remarkLintNoUndefinedReferences,
     remarkLintNoUnusedDefinitions
-  ]
+  ],
+  settings: {
+    bulletOrdered: '.',
+    listItemIndent: 'tab'
+  }
 }
 
 export default remarkPresetLintRecommended

--- a/packages/remark-preset-lint-recommended/readme.md
+++ b/packages/remark-preset-lint-recommended/readme.md
@@ -43,7 +43,7 @@ This preset configures [`remark-lint`][mono] with the following rules:
 | - | - |
 | [`remark-lint-final-newline`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-final-newline) | |
 | [`remark-lint-list-item-bullet-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-bullet-indent) | |
-| [`remark-lint-list-item-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent) | `'tab-size'` |
+| [`remark-lint-list-item-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent) | `'tab'` |
 | [`remark-lint-no-blockquote-without-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-blockquote-without-marker) | |
 | [`remark-lint-no-literal-urls`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-literal-urls) | |
 | [`remark-lint-ordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-style) | `'.'` |

--- a/packages/remark-preset-lint-recommended/readme.md
+++ b/packages/remark-preset-lint-recommended/readme.md
@@ -44,10 +44,10 @@ This preset configures [`remark-lint`][mono] with the following rules:
 | - | - |
 | [`remark-lint-final-newline`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-final-newline) | |
 | [`remark-lint-list-item-bullet-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-bullet-indent) | |
-| [`remark-lint-list-item-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent) | |
+| [`remark-lint-list-item-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent) | `'tab'` |
 | [`remark-lint-no-blockquote-without-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-blockquote-without-marker) | |
 | [`remark-lint-no-literal-urls`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-literal-urls) | |
-| [`remark-lint-ordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-style) | |
+| [`remark-lint-ordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-style) | `'.'` |
 | [`remark-lint-hard-break-spaces`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-hard-break-spaces) | |
 | [`remark-lint-no-duplicate-definitions`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-duplicate-definitions) | |
 | [`remark-lint-no-heading-content-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-heading-content-indent) | |

--- a/packages/remark-preset-lint-recommended/readme.md
+++ b/packages/remark-preset-lint-recommended/readme.md
@@ -17,6 +17,7 @@ Preset of [`remark-lint`][mono] rules to warn for some likely problems.
 *   [What is this?](#what-is-this)
 *   [When should I use this?](#when-should-i-use-this)
 *   [Rules](#rules)
+*   [Settings](#settings)
 *   [Install](#install)
 *   [Use](#use)
 *   [API](#api)
@@ -55,6 +56,16 @@ This preset configures [`remark-lint`][mono] with the following rules:
 | [`remark-lint-no-shortcut-reference-link`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-shortcut-reference-link) | |
 | [`remark-lint-no-undefined-references`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-undefined-references) | |
 | [`remark-lint-no-unused-definitions`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-unused-definitions) | |
+
+## Settings
+
+It sets the following remark [settings][configure].
+Settings are shared among all plugins --- particularly the corresponding rules and [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#options):
+
+| Name | Value |
+| - | - |
+| `settings.bulletOrdered` | `'.'` |
+| `settings.listItemIndent` | `'tab'` |
 
 ## Install
 
@@ -184,6 +195,8 @@ abide by its terms.
 [remark]: https://github.com/remarkjs/remark
 
 [mono]: https://github.com/remarkjs/remark-lint
+
+[configure]: https://github.com/remarkjs/remark-lint#configure
 
 [esm]: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
 

--- a/packages/remark-preset-lint-recommended/readme.md
+++ b/packages/remark-preset-lint-recommended/readme.md
@@ -44,10 +44,10 @@ This preset configures [`remark-lint`][mono] with the following rules:
 | - | - |
 | [`remark-lint-final-newline`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-final-newline) | |
 | [`remark-lint-list-item-bullet-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-bullet-indent) | |
-| [`remark-lint-list-item-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent) | `'tab'` |
+| [`remark-lint-list-item-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent) | [`settings.listItemIndent`](https://github.com/remarkjs/remark-lint#configure) is `'tab'` |
 | [`remark-lint-no-blockquote-without-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-blockquote-without-marker) | |
 | [`remark-lint-no-literal-urls`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-literal-urls) | |
-| [`remark-lint-ordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-style) | `'.'` |
+| [`remark-lint-ordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-style) | [`settings.bulletOrdered`](https://github.com/remarkjs/remark-lint#configure) is `'.'` |
 | [`remark-lint-hard-break-spaces`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-hard-break-spaces) | |
 | [`remark-lint-no-duplicate-definitions`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-duplicate-definitions) | |
 | [`remark-lint-no-heading-content-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-heading-content-indent) | |

--- a/packages/remark-preset-lint-recommended/readme.md
+++ b/packages/remark-preset-lint-recommended/readme.md
@@ -44,10 +44,10 @@ This preset configures [`remark-lint`][mono] with the following rules:
 | - | - |
 | [`remark-lint-final-newline`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-final-newline) | |
 | [`remark-lint-list-item-bullet-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-bullet-indent) | |
-| [`remark-lint-list-item-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent) | `'tab'` |
+| [`remark-lint-list-item-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent) | |
 | [`remark-lint-no-blockquote-without-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-blockquote-without-marker) | |
 | [`remark-lint-no-literal-urls`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-literal-urls) | |
-| [`remark-lint-ordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-style) | `'.'` |
+| [`remark-lint-ordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-style) | |
 | [`remark-lint-hard-break-spaces`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-hard-break-spaces) | |
 | [`remark-lint-no-duplicate-definitions`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-duplicate-definitions) | |
 | [`remark-lint-no-heading-content-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-heading-content-indent) | |

--- a/packages/unified-lint-rule/index.d.ts
+++ b/packages/unified-lint-rule/index.d.ts
@@ -24,6 +24,7 @@ export function lintRule<Tree extends Node = Node, Options = unknown>(
 >
 
 export type Rule<Tree extends Node = Node, Options = unknown> = (
+  this: Processor,
   node: Tree,
   file: VFile,
   options: Options

--- a/packages/unified-lint-rule/lib/index.js
+++ b/packages/unified-lint-rule/lib/index.js
@@ -67,7 +67,7 @@ export function lintRule(meta, rule) {
         }
 
         next()
-      })(tree, file, options)
+      }).call(this, tree, file, options)
     }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -263,9 +263,10 @@ remark()
   // Use `'error'` or `2` to treat messages as exceptions:
   .use(remarkLintFinalNewline, ['error'])
   .use(remarkLintFinalNewline, [2])
-  // Some rules correspond to `remark-stringify` settings which they obey by default:
-  .use(remarkLintUnorderedListMarkerStyle).use({settings: {bullet: '*'}})
-  // Some accept options, and what they exactly accept is different for
+  // Some rules respond to shared settings that `remark-stringify` also understands:
+  .use({settings: {bullet: '*'}})
+  .use(remarkLintUnorderedListMarkerStyle)
+  // Some rules accept options, and what they exactly accept is different for
   // each rule (sometimes a string, a number, or an object).
   // The following rule accepts a string:
   .use(remarkLintUnorderedListMarkerStyle, '*')

--- a/readme.md
+++ b/readme.md
@@ -238,7 +238,13 @@ For help creating your own rule, it’s suggested to look at existing rules and 
 
 <a name="configuring-remark-lint"></a>
 
-All rules can be configured in one standard way:
+Just like other remark plugins, there are a couple ways to configure rules.
+They all follow a standard approach:
+
+*   Pass a severity, options, or both to the rules themselves.
+    This affects each rule individually and takes highest precedence.
+*   Some rules correspond to settings that are shared among all remark plugins --- particularly [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#options).
+*   Using presets, you can change any combination of rules' severity, rules' options, or shared settings.
 
 ```js
 import {remark} from 'remark'
@@ -263,9 +269,6 @@ remark()
   // Use `'error'` or `2` to treat messages as exceptions:
   .use(remarkLintFinalNewline, ['error'])
   .use(remarkLintFinalNewline, [2])
-  // Some rules respond to shared settings that `remark-stringify` also understands:
-  .use({settings: {bullet: '*'}})
-  .use(remarkLintUnorderedListMarkerStyle)
   // Some rules accept options, and what they exactly accept is different for
   // each rule (sometimes a string, a number, or an object).
   // The following rule accepts a string:
@@ -277,8 +280,47 @@ remark()
   .use(remarkLintMaximumLineLength, [1, 72])
 ```
 
-See [`use()` in `unified`s readme][unified-use] for more info on how to use
+See [`use()` in `unified`'s readme][unified-use] for more info on how to use
 plugins.
+
+Use the following remark settings to configure both the corresponding rules and [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#options):
+
+<!--settings start-->
+
+| Setting | Rule |
+| - | - |
+| [`settings.bullet`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet) | [`remark-lint-unordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-unordered-list-marker-style) |
+| [`settings.bulletOrdered`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbulletordered) | [`remark-lint-ordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-style) |
+| [`settings.closeAtx`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionscloseatx) | [`remark-lint-heading-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-heading-style) |
+| [`settings.emphasis`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsemphasis) | [`remark-lint-emphasis-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-emphasis-marker) |
+| [`settings.fence`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfence) | [`remark-lint-fenced-code-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-fenced-code-marker) |
+| [`settings.fences`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsfences) | [`remark-lint-code-block-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-code-block-style) |
+| [`settings.incrementListMarker`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsincrementlistmarker) | [`remark-lint-ordered-list-marker-value`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-value) |
+| [`settings.listItemIndent`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent) | [`remark-lint-list-item-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent) |
+| [`settings.quote`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsquote) | [`remark-lint-link-title-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-link-title-style) |
+| [`settings.rule`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrule) | [`remark-lint-rule-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-rule-style) |
+| [`settings.ruleRepetition`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulerepetition) | [`remark-lint-rule-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-rule-style) |
+| [`settings.ruleSpaces`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsrulespaces) | [`remark-lint-rule-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-rule-style) |
+| [`settings.setext`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionssetext) | [`remark-lint-heading-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-heading-style) |
+| [`settings.strong`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsstrong) | [`remark-lint-strong-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-strong-marker) |
+
+<!--settings end-->
+
+```js
+import {remark} from 'remark'
+import remarkLintUnorderedListMarkerStyle from 'remark-lint-unordered-list-marker-style'
+
+remark()
+  .use(remarkLintUnorderedListMarkerStyle)
+  .use({settings: {bullet: '*'}})
+```
+
+See [remark][] for how to configure plugins and settings on the API, and [`remark-cli`][remark-cli] for the places the CLI looks for configuration.
+
+> 🧑‍🏫 **Info**: remark lint rules *check* markdown.
+> [`remark-stringify`][remark-stringify] *formats* markdown.
+> They behave consistently when you change shared settings that they both understand, but not if you pass options to rules individually.
+> Passing options to rules individually doesn't affect [`remark-stringify`][remark-stringify] or vice versa.
 
 > 🧑‍🏫 **Info**: messages in `remark-lint` are warnings instead of errors.
 > Other linters (such as ESLint) almost always use errors.
@@ -377,9 +419,9 @@ async function main() {
     // Few recommended rules.
     .use(remarkPresetLintRecommended)
     .use({
-      // `remark-lint-list-item-indent` is configured with `tab` in the
-      // recommended preset, but if we’d prefer something else, it can be
-      // reconfigured:
+      // `settings.listItemIndent` is set to `tab` in the
+      // recommended preset, but you can
+      // change it if you’d prefer something else:
       settings: {listItemIndent: 'one'}
     })
     .process('1) Hello, _Jupiter_ and *Neptune*!')
@@ -416,8 +458,7 @@ async function main() {
     .use(remarkLintEmphasisMarker)
     .use(remarkLintStrongMarker)
     .use({
-      // `remark-stringify` settings.
-      // The corresponding rules obey these by default.
+      // Configure both the rules and `remark-stringify`.
       settings: {emphasis: '*', strong: '*'}
     })
     .process('_Hello_, __world__!')
@@ -480,9 +521,9 @@ Now add a `remarkConfig` to your `package.json` to configure remark:
   /* … */
   "remarkConfig": {
     "settings": {
-      // `remark-lint-list-item-indent` is configured with `tab` in the
-      // recommended preset, but if we’d prefer something else, it can be
-      // reconfigured:
+      // `settings.listItemIndent` is set to `tab` in the
+      // recommended preset, but you can
+      // change it if you’d prefer something else:
       "listItemIndent": "one"
     },
     "plugins": [
@@ -530,7 +571,6 @@ Update `remarkConfig`:
   "remarkConfig": {
     "settings": {
       "emphasis": "*",
-      "listItemIndent": "one",
       "strong": "*"
     },
     "plugins": [
@@ -541,8 +581,8 @@ Update `remarkConfig`:
   /* … */
 ```
 
-`settings` configures both
-[`remark-stringify`][remark-stringify] and the corresponding rules, and explicitly prefers asterisks
+`settings` configures both the rules and
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#options), and explicitly prefers asterisks
 for emphasis and strong.
 Install the new dependencies:
 

--- a/readme.md
+++ b/readme.md
@@ -374,10 +374,10 @@ async function main() {
     .use(remarkPresetLintConsistent)
     // Few recommended rules.
     .use(remarkPresetLintRecommended)
-    // `remark-lint-list-item-indent` is configured with `tab-size` in the
+    // `remark-lint-list-item-indent` is configured with `tab` in the
     // recommended preset, but if we’d prefer something else, it can be
     // reconfigured:
-    .use(remarkLintListItemIndent, 'space')
+    .use(remarkLintListItemIndent, 'one')
     .process('1) Hello, _Jupiter_ and *Neptune*!')
 
   console.error(reporter(file))
@@ -478,12 +478,12 @@ Now add a `remarkConfig` to your `package.json` to configure remark:
     "plugins": [
       "remark-preset-lint-consistent", // Check that markdown is consistent.
       "remark-preset-lint-recommended", // Few recommended rules.
-      // `remark-lint-list-item-indent` is configured with `tab-size` in the
+      // `remark-lint-list-item-indent` is configured with `tab` in the
       // recommended preset, but if we’d prefer something else, it can be
       // reconfigured:
       [
         "remark-lint-list-item-indent",
-        "space"
+        "one"
       ]
     ]
   },
@@ -534,7 +534,7 @@ Update `remarkConfig`:
     "plugins": [
       "remark-preset-lint-consistent",
       "remark-preset-lint-recommended",
-      ["remark-lint-list-item-indent", "space"]
+      ["remark-lint-list-item-indent", "one"]
       ["remark-lint-emphasis-marker", "*"],
       ["remark-lint-strong-marker", "*"]
     ]

--- a/readme.md
+++ b/readme.md
@@ -263,7 +263,9 @@ remark()
   // Use `'error'` or `2` to treat messages as exceptions:
   .use(remarkLintFinalNewline, ['error'])
   .use(remarkLintFinalNewline, [2])
-  // Some rules accept options, and what they exactly accept is different for
+  // Some rules correspond to `remark-stringify` settings which they obey by default:
+  .use(remarkLintUnorderedListMarkerStyle).use({settings: {bullet: '*'}})
+  // Some accept options, and what they exactly accept is different for
   // each rule (sometimes a string, a number, or an object).
   // The following rule accepts a string:
   .use(remarkLintUnorderedListMarkerStyle, '*')
@@ -364,7 +366,6 @@ import {reporter} from 'vfile-reporter'
 import {remark} from 'remark'
 import remarkPresetLintConsistent from 'remark-preset-lint-consistent'
 import remarkPresetLintRecommended from 'remark-preset-lint-recommended'
-import remarkLintListItemIndent from 'remark-lint-list-item-indent'
 
 main()
 
@@ -374,10 +375,12 @@ async function main() {
     .use(remarkPresetLintConsistent)
     // Few recommended rules.
     .use(remarkPresetLintRecommended)
-    // `remark-lint-list-item-indent` is configured with `tab` in the
-    // recommended preset, but if we’d prefer something else, it can be
-    // reconfigured:
-    .use(remarkLintListItemIndent, 'one')
+    .use({
+      // `remark-lint-list-item-indent` is configured with `tab` in the
+      // recommended preset, but if we’d prefer something else, it can be
+      // reconfigured:
+      settings: {listItemIndent: 'one'}
+    })
     .process('1) Hello, _Jupiter_ and *Neptune*!')
 
   console.error(reporter(file))
@@ -398,8 +401,6 @@ Running that with `node example.js` yields:
 
 remark lint rules *check* markdown.
 [`remark-stringify`][remark-stringify] (used in remark) *formats* markdown.
-When you configure lint rules and use remark to format markdown, you must
-manually synchronize their configuration:
 
 ```js
 import {reporter} from 'vfile-reporter'
@@ -411,10 +412,12 @@ main()
 
 async function main() {
   const file = await remark()
-    .use(remarkLintEmphasisMarker, '*')
-    .use(remarkLintStrongMarker, '*')
+    .use(remarkLintEmphasisMarker)
+    .use(remarkLintStrongMarker)
     .use({
-      settings: {emphasis: '*', strong: '*'} // `remark-stringify` settings.
+      // `remark-stringify` settings.
+      // The corresponding rules obey these by default.
+      settings: {emphasis: '*', strong: '*'}
     })
     .process('_Hello_, __world__!')
 
@@ -475,16 +478,15 @@ Now add a `remarkConfig` to your `package.json` to configure remark:
 ```js
   /* … */
   "remarkConfig": {
-    "plugins": [
-      "remark-preset-lint-consistent", // Check that markdown is consistent.
-      "remark-preset-lint-recommended", // Few recommended rules.
+    "settings": {
       // `remark-lint-list-item-indent` is configured with `tab` in the
       // recommended preset, but if we’d prefer something else, it can be
       // reconfigured:
-      [
-        "remark-lint-list-item-indent",
-        "one"
-      ]
+      "listItemIndent": "one"
+    },
+    "plugins": [
+      "remark-preset-lint-consistent", // Check that markdown is consistent.
+      "remark-preset-lint-recommended" // Few recommended rules.
     ]
   },
   /* … */
@@ -503,8 +505,6 @@ npm run check
 
 remark lint rules *check* markdown.
 The CLI can *format* markdown.
-You can combine these features but have to manually synchronize their
-configuration.
 Please first follow the previous example (checking markdown on the CLI) and then
 change the npm script:
 
@@ -529,21 +529,19 @@ Update `remarkConfig`:
   "remarkConfig": {
     "settings": {
       "emphasis": "*",
+      "listItemIndent": "one",
       "strong": "*"
     },
     "plugins": [
       "remark-preset-lint-consistent",
-      "remark-preset-lint-recommended",
-      ["remark-lint-list-item-indent", "one"]
-      ["remark-lint-emphasis-marker", "*"],
-      ["remark-lint-strong-marker", "*"]
+      "remark-preset-lint-recommended"
     ]
   },
   /* … */
 ```
 
-This now includes `settings`, which configures
-[`remark-stringify`][remark-stringify], and explicitly prefers asterisks
+`settings` configures both
+[`remark-stringify`][remark-stringify] and the corresponding rules, and explicitly prefers asterisks
 for emphasis and strong.
 Install the new dependencies:
 

--- a/script/build-presets.js
+++ b/script/build-presets.js
@@ -29,7 +29,7 @@ presets(root).then((presetObjects) => {
   let index = -1
 
   while (++index < presetObjects.length) {
-    const {name, packages} = presetObjects[index]
+    const {name, packages, settings} = presetObjects[index]
     const base = path.resolve(root, name)
     /** @type {PackageJson} */
     const pack = JSON.parse(
@@ -311,6 +311,89 @@ presets(root).then((presetObjects) => {
         ]
       },
       {type: 'table', align: [], children: rows},
+      {
+        type: 'heading',
+        depth: 2,
+        children: [{type: 'text', value: 'Settings'}]
+      },
+      .../** @type {Array<BlockContent>} */ (
+        settings
+          ? [
+              {
+                type: 'paragraph',
+                children: [
+                  {type: 'text', value: 'It sets the following remark '},
+                  {
+                    type: 'linkReference',
+                    identifier: 'configure',
+                    referenceType: 'full',
+                    children: [{type: 'text', value: 'settings'}]
+                  },
+                  {
+                    type: 'text',
+                    value:
+                      '.\nSettings are shared among all plugins --- particularly the corresponding rules and '
+                  },
+                  {
+                    type: 'link',
+                    url: 'https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#options',
+                    title: null,
+                    children: [{type: 'inlineCode', value: 'remark-stringify'}]
+                  },
+                  {type: 'text', value: ':'}
+                ]
+              },
+              {
+                type: 'table',
+                align: [],
+                children: [
+                  {
+                    type: 'tableRow',
+                    children: [
+                      {
+                        type: 'tableCell',
+                        children: [{type: 'text', value: 'Name'}]
+                      },
+                      {
+                        type: 'tableCell',
+                        children: [{type: 'text', value: 'Value'}]
+                      }
+                    ]
+                  },
+                  ...Object.entries(settings).map(([name, value]) => ({
+                    type: 'tableRow',
+                    children: [
+                      {
+                        type: 'tableCell',
+                        children: [
+                          {type: 'inlineCode', value: `settings.${name}`}
+                        ]
+                      },
+                      {
+                        type: 'tableCell',
+                        children: [{type: 'inlineCode', value: inspect(value)}]
+                      }
+                    ]
+                  }))
+                ]
+              }
+            ]
+          : [
+              {
+                type: 'paragraph',
+                children: [
+                  {type: 'text', value: "It doesn't set any remark "},
+                  {
+                    type: 'linkReference',
+                    identifier: 'configure',
+                    referenceType: 'full',
+                    children: [{type: 'text', value: 'settings'}]
+                  },
+                  {type: 'text', value: '.'}
+                ]
+              }
+            ]
+      ),
       {
         type: 'heading',
         depth: 2,
@@ -663,6 +746,11 @@ presets(root).then((presetObjects) => {
         type: 'definition',
         identifier: 'mono',
         url: 'https://github.com/' + slug
+      },
+      {
+        type: 'definition',
+        identifier: 'configure',
+        url: `https://github.com/${slug}#configure`
       },
       {
         type: 'definition',

--- a/script/build-presets.js
+++ b/script/build-presets.js
@@ -112,8 +112,6 @@ presets(root).then((presetObjects) => {
         const url = remote + '/tree/main/packages/' + rule
         const option = packages[rule]
 
-        if (rule === 'remark-lint') continue
-
         rows.push({
           type: 'tableRow',
           children: [
@@ -130,9 +128,7 @@ presets(root).then((presetObjects) => {
             },
             {
               type: 'tableCell',
-              children: option
-                ? [{type: 'inlineCode', value: inspect(option)}]
-                : []
+              children: option || []
             }
           ]
         })

--- a/script/plugin/list-of-settings.js
+++ b/script/plugin/list-of-settings.js
@@ -1,0 +1,71 @@
+import path from 'node:path'
+import process from 'node:process'
+import {zone} from 'mdast-zone'
+import {repoUrl} from '../util/repo-url.js'
+import {rule} from '../util/rule.js'
+import {rules} from '../util/rules.js'
+
+const root = path.join(process.cwd(), 'packages')
+
+/** @type {import('unified').Plugin<Array<void>, import('mdast').Root>} */
+export default function listOfSettings() {
+  const rows = rules(root).flatMap((basename) =>
+    Array.from(
+      new Set(
+        Object.keys(rule(path.join(root, basename)).tests).flatMap(
+          (configuration) => {
+            /** @type {{settings: Record<string, unknown>}} */
+            const {settings} = JSON.parse(configuration)
+            return Object.keys(settings || {})
+          }
+        )
+      ),
+      (name) => [name, basename]
+    )
+  )
+  rows.sort()
+  /** @type {import('mdast').Table} */
+  const table = {
+    type: 'table',
+    children: [
+      {
+        type: 'tableRow',
+        children: [
+          {type: 'tableCell', children: [{type: 'text', value: 'Setting'}]},
+          {type: 'tableCell', children: [{type: 'text', value: 'Rule'}]}
+        ]
+      },
+      .../** @type {Array<import('mdast').TableRow>} */ (
+        rows.map(([name, basename]) => ({
+          type: 'tableRow',
+          children: [
+            {
+              type: 'tableCell',
+              children: [
+                {
+                  type: 'link',
+                  url: `https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#options${name.toLowerCase()}`,
+                  children: [{type: 'inlineCode', value: `settings.${name}`}]
+                }
+              ]
+            },
+            {
+              type: 'tableCell',
+              children: [
+                {
+                  type: 'link',
+                  url: repoUrl(path.join(root, basename, 'package.json')),
+                  children: [{type: 'inlineCode', value: basename}]
+                }
+              ]
+            }
+          ]
+        }))
+      )
+    ]
+  }
+
+  return (tree) => {
+    zone(tree, 'settings', (start, _, end) => [start, table, end])
+  }
+}

--- a/script/util/presets.js
+++ b/script/util/presets.js
@@ -3,6 +3,7 @@
  * @typedef {import('unified').Plugin} Plugin
  */
 
+import {toMarkdown} from 'mdast-util-to-markdown'
 import {promises as fs} from 'node:fs'
 import path from 'node:path'
 import url from 'node:url'
@@ -26,6 +27,7 @@ export async function presets(base) {
       // type-coverage:ignore-next-line
       const preset = presetMod.default
       const plugins = preset.plugins || []
+      const settings = preset.settings || {}
       /** @type {Record<string, unknown>} */
       const packages = {}
 
@@ -68,6 +70,77 @@ export async function presets(base) {
               (/** @type {string} */ $0) => '-' + $0.toLowerCase()
             )
         ] = option
+      }
+
+      if (typeof settings.fences === 'boolean') {
+        packages['remark-lint-code-block-style'] =
+          packages['remark-lint-code-block-style'] ||
+          (settings.fences ? 'fenced' : 'indented')
+      }
+
+      if (settings.emphasis) {
+        packages['remark-lint-emphasis-marker'] =
+          packages['remark-lint-emphasis-marker'] || settings.emphasis
+      }
+
+      if (settings.fence) {
+        packages['remark-lint-fenced-code-marker'] =
+          packages['remark-lint-fenced-code-marker'] || settings.fence
+      }
+
+      if (
+        typeof settings.setext === 'boolean' ||
+        typeof settings.closeAtx === 'boolean'
+      ) {
+        packages['remark-lint-heading-style'] =
+          packages['remark-lint-heading-style'] ||
+          (settings.setext
+            ? 'setext'
+            : settings.closeAtx
+            ? 'atx-closed'
+            : 'atx')
+      }
+
+      if (settings.quote) {
+        packages['remark-lint-link-title-style'] =
+          packages['remark-lint-link-title-style'] || settings.quote
+      }
+
+      if (settings.listItemIndent) {
+        packages['remark-lint-list-item-indent'] =
+          packages['remark-lint-list-item-indent'] || settings.listItemIndent
+      }
+
+      if (settings.bulletOrdered) {
+        packages['remark-lint-ordered-list-marker-style'] =
+          packages['remark-lint-ordered-list-marker-style'] ||
+          settings.bulletOrdered
+      }
+
+      if (typeof settings.incrementListMarker === 'boolean') {
+        packages['remark-lint-ordered-list-marker-value'] =
+          packages['remark-lint-ordered-list-marker-value'] ||
+          (settings.incrementListMarker ? 'ordered' : 'single')
+      }
+
+      if (
+        settings.rule !== undefined ||
+        settings.ruleRepetition !== undefined ||
+        typeof settings.ruleSpaces === 'boolean'
+      ) {
+        packages['remark-lint-rule-style'] =
+          packages['remark-lint-rule-style'] ||
+          toMarkdown({type: 'thematicBreak'}, settings).slice(0, -1)
+      }
+
+      if (settings.strong) {
+        packages['remark-lint-strong-marker'] =
+          packages['remark-lint-strong-marker'] || settings.strong
+      }
+
+      if (settings.bullet) {
+        packages['remark-lint-unordered-list-marker-style'] =
+          packages['remark-lint-unordered-list-marker-style'] || settings.bullet
       }
 
       return {name, packages, settings: preset.settings}

--- a/script/util/presets.js
+++ b/script/util/presets.js
@@ -9,7 +9,7 @@ import url from 'node:url'
 
 /**
  * @param {string} base
- * @returns {Promise<Array<{name: string, packages: Record<string, unknown>}>>}
+ * @returns {Promise<Array<{name: string, packages: Record<string, unknown>, settings: Record<string, unknown>|undefined}>>}
  */
 export async function presets(base) {
   const allFiles = await fs.readdir(base)
@@ -70,7 +70,7 @@ export async function presets(base) {
         ] = option
       }
 
-      return {name, packages}
+      return {name, packages, settings: preset.settings}
     })
   )
 }

--- a/script/util/rule.js
+++ b/script/util/rule.js
@@ -76,7 +76,7 @@ export function rule(filePath) {
 
   while (++index < examples.length) {
     const lines = examples[index].split('\n')
-    /** @type {{name: string, label?: 'input'|'output', config?: unknown, positionless?: boolean, gfm?: boolean}} */
+    /** @type {{name: string, label?: 'input'|'output', settings?: Record<string, unknown>, config?: unknown, positionless?: boolean, gfm?: boolean}} */
     let info
 
     try {
@@ -91,7 +91,10 @@ export function rule(filePath) {
     }
 
     const exampleValue = strip(lines.join('\n').replace(/^\r?\n/g, ''))
-    const configuration = JSON.stringify({config: info.config || true})
+    const configuration = JSON.stringify({
+      settings: info.settings,
+      config: info.config || true
+    })
     const name = info.name
     const context =
       configuration in tests

--- a/test.js
+++ b/test.js
@@ -301,8 +301,8 @@ function assertRule(t, rule, info) {
   for (configuration in tests) {
     if (own.call(tests, configuration)) {
       const checks = tests[configuration]
-      /** @type {{config: unknown}} */
-      const {config} = JSON.parse(configuration)
+      /** @type {{settings: Record<string, unknown>, config: unknown}} */
+      const {settings, config} = JSON.parse(configuration)
 
       t.test(configuration, (t) => {
         /** @type {string} */
@@ -314,7 +314,7 @@ function assertRule(t, rule, info) {
             const check = checks[name]
 
             t.test(name, (t) => {
-              assertFixture(t, rule, info, check, basename, config)
+              assertFixture(t, rule, info, check, basename, settings, config)
             })
           }
         }
@@ -331,15 +331,16 @@ function assertRule(t, rule, info) {
  * @param {Rule} info
  * @param {Check} fixture
  * @param {string} basename
+ * @param {Record<string, unknown>} settings
  * @param {unknown} config
  */
 /* eslint-disable-next-line max-params */
-function assertFixture(t, rule, info, fixture, basename, config) {
+function assertFixture(t, rule, info, fixture, basename, settings, config) {
   const ruleId = info.ruleId
   const file = toVFile(basename)
   const expected = fixture.output
   const positionless = fixture.positionless
-  let proc = remark().use(rule, config)
+  let proc = remark().use(rule, config).use({settings})
 
   if (fixture.gfm) proc.use(remarkGfm)
 
@@ -393,6 +394,7 @@ function assertFixture(t, rule, info, fixture, basename, config) {
     proc = remark()
       .use(() => (tree) => removePosition(tree))
       .use(rule, config)
+      .use({settings})
     if (fixture.gfm) proc.use(remarkGfm)
     proc.processSync(file)
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["script/**/*.js", "test.js"],
+  "include": ["script/**/*.js", "test.js", "types.d.ts"],
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["ES2020"],

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,3 @@
+interface Function {
+  displayName: string
+}


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

I'm interested in working on [this: Giving rules access to `settings`](https://github.com/remarkjs/remark-lint/issues/263#issuecomment-903311532).

Also, some rules might need access to [the `fileSet`](https://github.com/unifiedjs/unified-engine/blob/main/doc/plugins.md) too? but from what I could gather, while `settings` is accessible via `this` (processor: `this.data().settings`), `fileSet` isn't? Consequently I've appended it to the rule arguments, symmetric with how the other (`options`) attacher parameter is appended to the rule arguments, roughly.

Fixes https://github.com/remarkjs/remark-lint/issues/263#issuecomment-903311532

<!--do not edit: pr-->
