### PR TITLE
Fix Node in Actions on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,12 +8,10 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{matrix.node}}
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{matrix.node}}
-          #cache: npm
-      - run: npm install -g npm@7 # https://github.com/npm/cli/issues/4341#issuecomment-1040608101
+      - run: npm install -g npm@7 # See: <https://github.com/npm/cli/issues/4341#issuecomment-1040608101>
       - run: npm install -g npm
       - run: npm install
       - run: npm test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,12 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2
-      - uses: dcodeIO/setup-node-nvm@master
+      - name: Use Node.js ${{matrix.node}}
+        uses: actions/setup-node@v2
         with:
           node-version: ${{matrix.node}}
+          #cache: npm
+      - run: npm install -g npm@7 # https://github.com/npm/cli/issues/4341#issuecomment-1040608101
       - run: npm install -g npm
       - run: npm install
       - run: npm test
@@ -22,4 +25,4 @@ jobs:
           - windows-latest
         node:
           - lts/erbium
-          - node
+          - lts/*


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

There's an apparent conflict between new versions of Node.js (? 17.5.0)/npm (? 8.4.1) and old versions of nvm-windows (? [1.1.7](https://github.com/dcodeIO/setup-node-nvm/blob/3bc09a3f6f58358a453eccc31a88b0c661cba9f9/install.ps1#L6)):
- https://github.com/remarkjs/remark-lint/runs/5239128363?check_suite_focus=true#step:4:4
- https://github.com/npm/cli/issues/4340#issuecomment-1035608510

I didn't get to the absolute bottom of it because https://github.com/dcodeIO/setup-node-nvm hasn't been updated in a while and describes itself as merely a placeholder until https://github.com/actions/setup-node supports aliases, which [it now seems to](https://github.com/actions/setup-node#supported-version-syntax) --- except for a `node` alias: https://github.com/actions/setup-node/pull/279

Additionally there's a problem installing npm globally on Windows when starting below version 7.5.4: https://github.com/npm/cli/issues/4341#issuecomment-1040608101

So, what I did in this PR is:
- Replace dcodeIO/setup-node-nvm with actions/setup-node
- Replace the `node` alias with `17`, until actions/setup-node supports something like https://github.com/actions/setup-node/pull/279
- Use `npm install -g npm@latest-7` to get around https://github.com/npm/cli/issues/4341#issuecomment-1040608101 and install npm with workspaces on lts/erbium

<!--do not edit: pr-->
