### PR TITLE
Harmonize list item indent literals

### DIFF
--- a/packages/remark-lint-list-item-indent/index.js
+++ b/packages/remark-lint-list-item-indent/index.js
@@ -6,14 +6,14 @@
  *
  * ## API
  *
- * The following options (default: `'tab-size'`) are accepted:
+ * The following options (default: `'tab'`) are accepted:
  *
- * *   `'space'`
+ * *   `'one'`
  *     — prefer a single space
- * *   `'tab-size'`
+ * *   `'tab'`
  *     — prefer spaces the size of the next tab stop
  * *   `'mixed'`
- *     — prefer `'space'` for tight lists and `'tab-size'` for loose lists
+ *     — prefer `'one'` for tight lists and `'tab'` for loose lists
  *
  * ## Recommendation
  *
@@ -39,17 +39,17 @@
  * especially with how they interact with indented code.
  * CommonMark made that a *lot* better, but there remain (documented but
  * complex) edge cases and some behavior intuitive.
- * Due to this, the default of this list is `'tab-size'`, which worked the best
+ * Due to this, the default of this list is `'tab'`, which worked the best
  * in most markdown parsers.
  * Currently, the situation between markdown parsers is better, so choosing
- * `'space'` (which seems to be the most common style used by authors) should
+ * `'one'` (which seems to be the most common style used by authors) should
  * be okay.
  *
  * ## Fix
  *
  * [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
- * uses `'tab-size'` (named `'tab'` there) by default.
- * [`listItemIndent: '1'` (for `'space'`) or `listItemIndent: 'mixed'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent)
+ * uses `'tab'` by default.
+ * [`listItemIndent: 'one'` or `listItemIndent: 'mixed'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent)
  * is supported.
  *
  * @module list-item-indent
@@ -96,7 +96,7 @@
  *   ····item.
  *
  * @example
- *   {"name": "ok.md", "setting": "space"}
+ *   {"name": "ok.md", "setting": "one"}
  *
  *   *·List item.
  *
@@ -113,24 +113,24 @@
  *   ··item.
  *
  * @example
- *   {"name": "not-ok.md", "setting": "space", "label": "input"}
+ *   {"name": "not-ok.md", "setting": "one", "label": "input"}
  *
  *   *···List
  *   ····item.
  *
  * @example
- *   {"name": "not-ok.md", "setting": "space", "label": "output"}
+ *   {"name": "not-ok.md", "setting": "one", "label": "output"}
  *
  *    1:5: Incorrect list-item indent: remove 2 spaces
  *
  * @example
- *   {"name": "not-ok.md", "setting": "tab-size", "label": "input"}
+ *   {"name": "not-ok.md", "setting": "tab", "label": "input"}
  *
  *   *·List
  *   ··item.
  *
  * @example
- *   {"name": "not-ok.md", "setting": "tab-size", "label": "output"}
+ *   {"name": "not-ok.md", "setting": "tab", "label": "output"}
  *
  *    1:3: Incorrect list-item indent: add 2 spaces
  *
@@ -147,12 +147,12 @@
  * @example
  *   {"name": "not-ok.md", "setting": "💩", "label": "output", "positionless": true}
  *
- *    1:1: Incorrect list-item indent style `💩`: use either `'tab-size'`, `'space'`, or `'mixed'`
+ *    1:1: Incorrect list-item indent style `💩`: use either `'tab'`, `'one'`, or `'mixed'`
  */
 
 /**
  * @typedef {import('mdast').Root} Root
- * @typedef {'tab-size'|'space'|'mixed'} Options
+ * @typedef {'tab'|'one'|'mixed'} Options
  */
 
 import {lintRule} from 'unified-lint-rule'
@@ -167,14 +167,21 @@ const remarkLintListItemIndent = lintRule(
     url: 'https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent#readme'
   },
   /** @type {import('unified-lint-rule').Rule<Root, Options>} */
-  (tree, file, option = 'tab-size') => {
+  (tree, file, option = 'tab') => {
     const value = String(file)
+    // TODO(next major): Remove legacy fallbacks.
+    option =
+      /** @type {unknown} */ (option) === 'tab-size'
+        ? /* c8 ignore next */ 'tab'
+        : /** @type {unknown} */ (option) === 'space'
+        ? /* c8 ignore next */ 'one'
+        : option
 
-    if (option !== 'tab-size' && option !== 'space' && option !== 'mixed') {
+    if (option !== 'tab' && option !== 'one' && option !== 'mixed') {
       file.fail(
         'Incorrect list-item indent style `' +
           option +
-          "`: use either `'tab-size'`, `'space'`, or `'mixed'`"
+          "`: use either `'tab'`, `'one'`, or `'mixed'`"
       )
     }
 
@@ -196,7 +203,7 @@ const remarkLintListItemIndent = lintRule(
         const bulletSize = marker.replace(/\s+$/, '').length
 
         const style =
-          option === 'tab-size' || (option === 'mixed' && spread)
+          option === 'tab' || (option === 'mixed' && spread)
             ? Math.ceil(bulletSize / 4) * 4
             : bulletSize + 1
 

--- a/packages/remark-lint-list-item-indent/readme.md
+++ b/packages/remark-lint-list-item-indent/readme.md
@@ -47,7 +47,7 @@ This rule is included in the following presets:
 | Preset | Setting |
 | - | - |
 | [`remark-preset-lint-markdown-style-guide`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-markdown-style-guide) | `'mixed'` |
-| [`remark-preset-lint-recommended`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-recommended) | `'tab-size'` |
+| [`remark-preset-lint-recommended`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-preset-lint-recommended) | `'tab'` |
 
 ## Install
 
@@ -126,14 +126,14 @@ The default export is `remarkLintListItemIndent`.
 This rule supports standard configuration that all remark lint rules accept
 (such as `false` to turn it off or `[1, options]` to configure it).
 
-The following options (default: `'tab-size'`) are accepted:
+The following options (default: `'tab'`) are accepted:
 
-*   `'space'`
+*   `'one'`
     — prefer a single space
-*   `'tab-size'`
+*   `'tab'`
     — prefer spaces the size of the next tab stop
 *   `'mixed'`
-    — prefer `'space'` for tight lists and `'tab-size'` for loose lists
+    — prefer `'one'` for tight lists and `'tab'` for loose lists
 
 ## Recommendation
 
@@ -159,17 +159,17 @@ Historically, how indentation of lists works in markdown has been a mess,
 especially with how they interact with indented code.
 CommonMark made that a *lot* better, but there remain (documented but
 complex) edge cases and some behavior intuitive.
-Due to this, the default of this list is `'tab-size'`, which worked the best
+Due to this, the default of this list is `'tab'`, which worked the best
 in most markdown parsers.
 Currently, the situation between markdown parsers is better, so choosing
-`'space'` (which seems to be the most common style used by authors) should
+`'one'` (which seems to be the most common style used by authors) should
 be okay.
 
 ## Fix
 
 [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify)
-uses `'tab-size'` (named `'tab'` there) by default.
-[`listItemIndent: '1'` (for `'space'`) or `listItemIndent: 'mixed'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent)
+uses `'tab'` by default.
+[`listItemIndent: 'one'` or `listItemIndent: 'mixed'`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent)
 is supported.
 
 ## Examples
@@ -250,7 +250,7 @@ When configured with `'mixed'`.
 
 ##### `ok.md`
 
-When configured with `'space'`.
+When configured with `'one'`.
 
 ###### In
 
@@ -278,7 +278,7 @@ No messages.
 
 ##### `not-ok.md`
 
-When configured with `'space'`.
+When configured with `'one'`.
 
 ###### In
 
@@ -297,7 +297,7 @@ When configured with `'space'`.
 
 ##### `not-ok.md`
 
-When configured with `'tab-size'`.
+When configured with `'tab'`.
 
 ###### In
 
@@ -321,7 +321,7 @@ When configured with `'💩'`.
 ###### Out
 
 ```text
-1:1: Incorrect list-item indent style `💩`: use either `'tab-size'`, `'space'`, or `'mixed'`
+1:1: Incorrect list-item indent style `💩`: use either `'tab'`, `'one'`, or `'mixed'`
 ```
 
 ## Compatibility

--- a/packages/remark-preset-lint-markdown-style-guide/index.js
+++ b/packages/remark-preset-lint-markdown-style-guide/index.js
@@ -73,7 +73,7 @@
  *  "plugins": [
  *    …
  *    "remark-preset-lint-markdown-style-guide",
- * +  ["remark-lint-list-item-indent", "space"],
+ * +  ["remark-lint-list-item-indent", "one"],
  *    …
  *  ]
  * ```

--- a/packages/remark-preset-lint-markdown-style-guide/readme.md
+++ b/packages/remark-preset-lint-markdown-style-guide/readme.md
@@ -105,7 +105,7 @@ like so:
  "plugins": [
    …
    "remark-preset-lint-markdown-style-guide",
-+  ["remark-lint-list-item-indent", "space"],
++  ["remark-lint-list-item-indent", "one"],
    …
  ]
 ```

--- a/packages/remark-preset-lint-recommended/index.js
+++ b/packages/remark-preset-lint-recommended/index.js
@@ -35,7 +35,7 @@ const remarkPresetLintRecommended = {
     remarkLintFinalNewline,
     // Rendering across vendors differs greatly if using other styles.
     remarkLintListItemBulletIndent,
-    [remarkLintListItemIndent, 'tab-size'],
+    [remarkLintListItemIndent, 'tab'],
     remarkLintNoBlockquoteWithoutMarker,
     remarkLintNoLiteralUrls,
     [remarkLintOrderedListMarkerStyle, '.'],

--- a/packages/remark-preset-lint-recommended/readme.md
+++ b/packages/remark-preset-lint-recommended/readme.md
@@ -43,7 +43,7 @@ This preset configures [`remark-lint`][mono] with the following rules:
 | - | - |
 | [`remark-lint-final-newline`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-final-newline) | |
 | [`remark-lint-list-item-bullet-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-bullet-indent) | |
-| [`remark-lint-list-item-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent) | `'tab-size'` |
+| [`remark-lint-list-item-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent) | `'tab'` |
 | [`remark-lint-no-blockquote-without-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-blockquote-without-marker) | |
 | [`remark-lint-no-literal-urls`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-literal-urls) | |
 | [`remark-lint-ordered-list-marker-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-ordered-list-marker-style) | `'.'` |

--- a/packages/unified-lint-rule/lib/index.js
+++ b/packages/unified-lint-rule/lib/index.js
@@ -83,9 +83,7 @@ function coerce(name, value) {
   /** @type {Array<unknown>} */
   let result
 
-  if (typeof value === 'boolean') {
-    result = [value]
-  } else if (value === null || value === undefined) {
+  if (value === null || value === undefined) {
     result = [1]
   } else if (
     Array.isArray(value) &&

--- a/readme.md
+++ b/readme.md
@@ -374,10 +374,10 @@ async function main() {
     .use(remarkPresetLintConsistent)
     // Few recommended rules.
     .use(remarkPresetLintRecommended)
-    // `remark-lint-list-item-indent` is configured with `tab-size` in the
+    // `remark-lint-list-item-indent` is configured with `tab` in the
     // recommended preset, but if we’d prefer something else, it can be
     // reconfigured:
-    .use(remarkLintListItemIndent, 'space')
+    .use(remarkLintListItemIndent, 'one')
     .process('1) Hello, _Jupiter_ and *Neptune*!')
 
   console.error(reporter(file))
@@ -478,12 +478,12 @@ Now add a `remarkConfig` to your `package.json` to configure remark:
     "plugins": [
       "remark-preset-lint-consistent", // Check that markdown is consistent.
       "remark-preset-lint-recommended", // Few recommended rules.
-      // `remark-lint-list-item-indent` is configured with `tab-size` in the
+      // `remark-lint-list-item-indent` is configured with `tab` in the
       // recommended preset, but if we’d prefer something else, it can be
       // reconfigured:
       [
         "remark-lint-list-item-indent",
-        "space"
+        "one"
       ]
     ]
   },
@@ -534,7 +534,7 @@ Update `remarkConfig`:
     "plugins": [
       "remark-preset-lint-consistent",
       "remark-preset-lint-recommended",
-      ["remark-lint-list-item-indent", "space"]
+      ["remark-lint-list-item-indent", "one"]
       ["remark-lint-emphasis-marker", "*"],
       ["remark-lint-strong-marker", "*"]
     ]


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Whereas [remark-stringify](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionslistitemindent) and [mdast-util-to-markdown](https://github.com/syntax-tree/mdast-util-to-markdown#optionslistitemindent) accept only `'one'`, `'tab'`, or `'mixed'`, remark-lint-list-item-indent accepts only `'space'`, `'tab-size'`, or `'mixed'`.

What do you think about allowing them to accept either the current or the preferred literals (whichever those are), and maybe dropping support for all but the preferred literals at some future point?

<!--do not edit: pr-->
