### PR TITLE
Add settings for enforced styles to presets

### DIFF
--- a/packages/remark-preset-lint-consistent/readme.md
+++ b/packages/remark-preset-lint-consistent/readme.md
@@ -17,6 +17,7 @@ Preset of [`remark-lint`][mono] rules to warn for inconsistencies.
 *   [What is this?](#what-is-this)
 *   [When should I use this?](#when-should-i-use-this)
 *   [Rules](#rules)
+*   [Settings](#settings)
 *   [Install](#install)
 *   [Use](#use)
 *   [API](#api)
@@ -53,6 +54,10 @@ This preset configures [`remark-lint`][mono] with the following rules:
 | [`remark-lint-rule-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-rule-style) | `'consistent'` |
 | [`remark-lint-strong-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-strong-marker) | `'consistent'` |
 | [`remark-lint-table-cell-padding`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-table-cell-padding) | `'consistent'` |
+
+## Settings
+
+It doesn't set any remark [settings][configure].
 
 ## Install
 
@@ -182,6 +187,8 @@ abide by its terms.
 [remark]: https://github.com/remarkjs/remark
 
 [mono]: https://github.com/remarkjs/remark-lint
+
+[configure]: https://github.com/remarkjs/remark-lint#configure
 
 [esm]: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
 

--- a/packages/remark-preset-lint-markdown-style-guide/index.js
+++ b/packages/remark-preset-lint-markdown-style-guide/index.js
@@ -285,7 +285,20 @@ const remarkPresetLintMarkdownStyleGuide = {
 
     // https://cirosantilli.com/markdown-style-guide/#email-automatic-links.
     // Not checked.
-  ]
+  ],
+  settings: {
+    bullet: '-',
+    bulletOrdered: '.',
+    emphasis: '*',
+    fence: '`',
+    fences: true,
+    incrementListMarker: false,
+    listItemIndent: 'mixed',
+    quote: '"',
+    rule: '-',
+    setext: false,
+    strong: '*'
+  }
 }
 
 export default remarkPresetLintMarkdownStyleGuide

--- a/packages/remark-preset-lint-markdown-style-guide/readme.md
+++ b/packages/remark-preset-lint-markdown-style-guide/readme.md
@@ -17,6 +17,7 @@ Preset of [`remark-lint`][mono] rules that follow an opinionated style guide.
 *   [What is this?](#what-is-this)
 *   [When should I use this?](#when-should-i-use-this)
 *   [Rules](#rules)
+*   [Settings](#settings)
 *   [Install](#install)
 *   [Use](#use)
 *   [API](#api)
@@ -175,6 +176,25 @@ This preset configures [`remark-lint`][mono] with the following rules:
 | [`remark-lint-no-emphasis-as-heading`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-emphasis-as-heading) | |
 | [`remark-lint-no-literal-urls`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-literal-urls) | |
 
+## Settings
+
+It sets the following remark [settings][configure].
+Settings are shared among all plugins --- particularly [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#options):
+
+| Name | Value |
+| - | - |
+| `settings.bullet` | `'-'` |
+| `settings.bulletOrdered` | `'.'` |
+| `settings.emphasis` | `'*'` |
+| `settings.fence` | ``'`'`` |
+| `settings.fences` | `true` |
+| `settings.incrementListMarker` | `false` |
+| `settings.listItemIndent` | `'mixed'` |
+| `settings.quote` | `'"'` |
+| `settings.rule` | `'-'` |
+| `settings.setext` | `false` |
+| `settings.strong` | `'*'` |
+
 ## Install
 
 This package is [ESM only][esm].
@@ -303,6 +323,8 @@ abide by its terms.
 [remark]: https://github.com/remarkjs/remark
 
 [mono]: https://github.com/remarkjs/remark-lint
+
+[configure]: https://github.com/remarkjs/remark-lint#configure
 
 [esm]: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
 

--- a/packages/remark-preset-lint-recommended/index.js
+++ b/packages/remark-preset-lint-recommended/index.js
@@ -48,7 +48,11 @@ const remarkPresetLintRecommended = {
     remarkLintNoShortcutReferenceLink,
     remarkLintNoUndefinedReferences,
     remarkLintNoUnusedDefinitions
-  ]
+  ],
+  settings: {
+    bulletOrdered: '.',
+    listItemIndent: 'tab'
+  }
 }
 
 export default remarkPresetLintRecommended

--- a/packages/remark-preset-lint-recommended/readme.md
+++ b/packages/remark-preset-lint-recommended/readme.md
@@ -17,6 +17,7 @@ Preset of [`remark-lint`][mono] rules to warn for some likely problems.
 *   [What is this?](#what-is-this)
 *   [When should I use this?](#when-should-i-use-this)
 *   [Rules](#rules)
+*   [Settings](#settings)
 *   [Install](#install)
 *   [Use](#use)
 *   [API](#api)
@@ -55,6 +56,16 @@ This preset configures [`remark-lint`][mono] with the following rules:
 | [`remark-lint-no-shortcut-reference-link`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-shortcut-reference-link) | |
 | [`remark-lint-no-undefined-references`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-undefined-references) | |
 | [`remark-lint-no-unused-definitions`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-unused-definitions) | |
+
+## Settings
+
+It sets the following remark [settings][configure].
+Settings are shared among all plugins --- particularly [`remark-stringify`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#options):
+
+| Name | Value |
+| - | - |
+| `settings.bulletOrdered` | `'.'` |
+| `settings.listItemIndent` | `'tab'` |
 
 ## Install
 
@@ -184,6 +195,8 @@ abide by its terms.
 [remark]: https://github.com/remarkjs/remark
 
 [mono]: https://github.com/remarkjs/remark-lint
+
+[configure]: https://github.com/remarkjs/remark-lint#configure
 
 [esm]: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
 

--- a/script/build-presets.js
+++ b/script/build-presets.js
@@ -29,7 +29,7 @@ presets(root).then((presetObjects) => {
   let index = -1
 
   while (++index < presetObjects.length) {
-    const {name, packages} = presetObjects[index]
+    const {name, packages, settings} = presetObjects[index]
     const base = path.resolve(root, name)
     /** @type {PackageJson} */
     const pack = JSON.parse(
@@ -311,6 +311,89 @@ presets(root).then((presetObjects) => {
         ]
       },
       {type: 'table', align: [], children: rows},
+      {
+        type: 'heading',
+        depth: 2,
+        children: [{type: 'text', value: 'Settings'}]
+      },
+      .../** @type {Array<BlockContent>} */ (
+        settings
+          ? [
+              {
+                type: 'paragraph',
+                children: [
+                  {type: 'text', value: 'It sets the following remark '},
+                  {
+                    type: 'linkReference',
+                    identifier: 'configure',
+                    referenceType: 'full',
+                    children: [{type: 'text', value: 'settings'}]
+                  },
+                  {
+                    type: 'text',
+                    value:
+                      '.\nSettings are shared among all plugins --- particularly '
+                  },
+                  {
+                    type: 'link',
+                    url: 'https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#options',
+                    title: null,
+                    children: [{type: 'inlineCode', value: 'remark-stringify'}]
+                  },
+                  {type: 'text', value: ':'}
+                ]
+              },
+              {
+                type: 'table',
+                align: [],
+                children: [
+                  {
+                    type: 'tableRow',
+                    children: [
+                      {
+                        type: 'tableCell',
+                        children: [{type: 'text', value: 'Name'}]
+                      },
+                      {
+                        type: 'tableCell',
+                        children: [{type: 'text', value: 'Value'}]
+                      }
+                    ]
+                  },
+                  ...Object.entries(settings).map(([name, value]) => ({
+                    type: 'tableRow',
+                    children: [
+                      {
+                        type: 'tableCell',
+                        children: [
+                          {type: 'inlineCode', value: `settings.${name}`}
+                        ]
+                      },
+                      {
+                        type: 'tableCell',
+                        children: [{type: 'inlineCode', value: inspect(value)}]
+                      }
+                    ]
+                  }))
+                ]
+              }
+            ]
+          : [
+              {
+                type: 'paragraph',
+                children: [
+                  {type: 'text', value: "It doesn't set any remark "},
+                  {
+                    type: 'linkReference',
+                    identifier: 'configure',
+                    referenceType: 'full',
+                    children: [{type: 'text', value: 'settings'}]
+                  },
+                  {type: 'text', value: '.'}
+                ]
+              }
+            ]
+      ),
       {
         type: 'heading',
         depth: 2,
@@ -663,6 +746,11 @@ presets(root).then((presetObjects) => {
         type: 'definition',
         identifier: 'mono',
         url: 'https://github.com/' + slug
+      },
+      {
+        type: 'definition',
+        identifier: 'configure',
+        url: `https://github.com/${slug}#configure`
       },
       {
         type: 'definition',

--- a/script/util/presets.js
+++ b/script/util/presets.js
@@ -9,7 +9,7 @@ import url from 'node:url'
 
 /**
  * @param {string} base
- * @returns {Promise<Array<{name: string, packages: Record<string, unknown>}>>}
+ * @returns {Promise<Array<{name: string, packages: Record<string, unknown>, settings: Record<string, unknown>|undefined}>>}
  */
 export async function presets(base) {
   const allFiles = await fs.readdir(base)
@@ -70,7 +70,7 @@ export async function presets(base) {
         ] = option
       }
 
-      return {name, packages}
+      return {name, packages, settings: preset.settings}
     })
   )
 }


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

What I did was, for each preset rule with remark-stringify options in that rule's "fix" documentation, I added that option to the preset's settings.

What this does is, you can apply the preset's remark-stringify options with, e.g.
```sh
remark --output --use remark-preset-lint-markdown-style-guide input.md
```

For example:
- remark-preset-lint-markdown-style-guide uses [`[remarkLintUnorderedListMarkerStyle, '-']`](https://github.com/jablko/remark-lint/blob/patch-4/packages/remark-preset-lint-markdown-style-guide/index.js#L217)
- [remark-lint-unordered-list-marker-style's "fix" documentation](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-unordered-list-marker-style#fix) points to [`settings.bullet`](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#optionsbullet)
- &therefore; I added [`bullet: '-'`](https://github.com/jablko/remark-lint/blob/patch-4/packages/remark-preset-lint-markdown-style-guide/index.js#L290) -> remark-preset-lint-markdown-style-guide's settings

<!--do not edit: pr-->
