### PR TITLE
Add type for rules' callback parameter

### DIFF
--- a/packages/unified-lint-rule/index.d.ts
+++ b/packages/unified-lint-rule/index.d.ts
@@ -19,14 +19,15 @@ export function lintRule<Tree extends Node = Node, Options = unknown>(
   name: string | RuleMeta,
   rule: Rule<Tree, Options>
 ): Plugin<
-  void[] | [Options | [boolean | Label | Severity, (Options | undefined)?]],
+  [(Options | [Label | Severity, (Options | undefined)?] | undefined | void)?],
   Tree
 >
 
 export type Rule<Tree extends Node = Node, Options = unknown> = (
   node: Tree,
   file: VFile,
-  options: Options
+  options: Options,
+  next: Callback
 ) => Promise<Tree | undefined | void> | Tree | undefined | void
 
 export {Severity, Label} from './lib/index.js'


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Transformers have [a `next` parameter](https://github.com/unifiedjs/unified/blob/6b060c2a229049e1bc0e7ea51920b36efb069f9f/index.d.ts#L658) that was missing from the `Rule` type, so rules that use it don't type check.

<!--do not edit: pr-->
