### PR TITLE
Remove boolean fallback for ancient remark

### DIFF
--- a/packages/unified-lint-rule/lib/index.js
+++ b/packages/unified-lint-rule/lib/index.js
@@ -83,9 +83,7 @@ function coerce(name, value) {
   /** @type {Array<unknown>} */
   let result
 
-  if (typeof value === 'boolean') {
-    result = [value]
-  } else if (value === null || value === undefined) {
+  if (value === null || value === undefined) {
     result = [1]
   } else if (
     Array.isArray(value) &&


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Should this boolean branch be removed, along with this comment? https://github.com/remarkjs/remark-lint/commit/4a832b145ef9087e2619eb7b2144e02830130c11#diff-fecb2d96324cc527540b9781510b84d13095032247186df5ce672b22171c78dcL51-L52

Since https://github.com/unifiedjs/unified/pull/185 it's untested, as before https://github.com/unifiedjs/unified/pull/150.

<!--do not edit: pr-->
