### PR TITLE
Combine severity types

### DIFF
--- a/packages/unified-lint-rule/index.d.ts
+++ b/packages/unified-lint-rule/index.d.ts
@@ -1,7 +1,7 @@
 import type {Node} from 'unist'
 import type {VFile} from 'vfile'
 import type {Plugin} from 'unified'
-import type {Label, Severity} from './lib/index.js'
+import type {Severity} from './lib/index.js'
 
 export interface RuleMeta {
   /**
@@ -18,10 +18,7 @@ export interface RuleMeta {
 export function lintRule<Tree extends Node = Node, Options = unknown>(
   name: string | RuleMeta,
   rule: Rule<Tree, Options>
-): Plugin<
-  void[] | [Options | [boolean | Label | Severity, (Options | undefined)?]],
-  Tree
->
+): Plugin<void[] | [Options | [Severity, (Options | undefined)?]], Tree>
 
 export type Rule<Tree extends Node = Node, Options = unknown> = (
   node: Tree,
@@ -29,4 +26,4 @@ export type Rule<Tree extends Node = Node, Options = unknown> = (
   options: Options
 ) => Promise<Tree | undefined | void> | Tree | undefined | void
 
-export {Severity, Label} from './lib/index.js'
+export {Severity} from './lib/index.js'

--- a/packages/unified-lint-rule/lib/index.js
+++ b/packages/unified-lint-rule/lib/index.js
@@ -2,9 +2,7 @@
  * @typedef {import('unist').Node} Node
  * @typedef {import('vfile').VFile} VFile
  *
- * @typedef {0|1|2} Severity
- * @typedef {'warn'|'on'|'off'|'error'} Label
- * @typedef {[Severity, ...Array<unknown>]} SeverityTuple
+ * @typedef {boolean|'off'|'on'|'warn'|'error'|0|1|2} Severity
  *
  * @typedef RuleMeta
  * @property {string} origin name of the lint rule
@@ -38,11 +36,11 @@ export function lintRule(meta, rule) {
 
   /** @type {import('unified').Plugin<[unknown]|Array<void>>} */
   function plugin(config) {
-    const [severity, options] = coerce(ruleId, config)
+    const [number, options] = coerce(ruleId, config)
 
-    if (!severity) return
+    if (!number) return
 
-    const fatal = severity === 2
+    const fatal = number === 2
 
     return (tree, file, next) => {
       let index = file.messages.length - 1
@@ -75,7 +73,7 @@ export function lintRule(meta, rule) {
  *
  * @param {string} name
  * @param {unknown} config
- * @returns {SeverityTuple}
+ * @returns {[Severity&number, ...Array<unknown>]}
  */
 function coerce(name, config) {
   if (!Array.isArray(config)) return [1, config]


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Another unimportant change: What do you think about adding the severity string literals to the `Severity` type? The purely-numeric type (`{0|1|2}`) is an internal detail, I think?

<!--do not edit: pr-->
