### PR TITLE
Fix types of rule arguments

### DIFF
--- a/packages/unified-lint-rule/index.d.ts
+++ b/packages/unified-lint-rule/index.d.ts
@@ -19,7 +19,7 @@ export function lintRule<Tree extends Node = Node, Options = unknown>(
   name: string | RuleMeta,
   rule: Rule<Tree, Options>
 ): Plugin<
-  void[] | [Options | Label | Severity] | [boolean | Label | Severity, Options],
+  void[] | [Options | [boolean | Label | Severity, (Options | undefined)?]],
   Tree
 >
 

--- a/readme.md
+++ b/readme.md
@@ -269,7 +269,8 @@ remark()
   .use(remarkLintUnorderedListMarkerStyle, '*')
   .use(remarkLintUnorderedListMarkerStyle, ['on', '*'])
   .use(remarkLintUnorderedListMarkerStyle, [1, '*'])
-  // The following rule accepts a number, numbers *must* be passed in arrays:
+  // The following rule accepts a number:
+  .use(remarkLintMaximumLineLength, 72)
   .use(remarkLintMaximumLineLength, ['on', 72])
   .use(remarkLintMaximumLineLength, [1, 72])
 ```


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Non-array arguments are a rule's options, not a severity.

Makes `remark().use(remarkLintUnorderedListMarkerStyle, 'off')` a type error, to match the runtime error:
```
1:1: Incorrect unordered list item marker style `off`: use either `'-'`, `'*'`, or `'+'`
```

<!--do not edit: pr-->
