### PR TITLE
Type-check lintRule() implementation

### DIFF
--- a/packages/unified-lint-rule/index.d.ts
+++ b/packages/unified-lint-rule/index.d.ts
@@ -1,7 +1,7 @@
 import type {Node} from 'unist'
 import type {VFile} from 'vfile'
 import type {Plugin} from 'unified'
-import type {Label, Severity} from './lib/index.js'
+import type {Label, Rule, Severity} from './lib/index.js'
 
 export interface RuleMeta {
   /**
@@ -23,10 +23,4 @@ export function lintRule<Tree extends Node = Node, Options = unknown>(
   Tree
 >
 
-export type Rule<Tree extends Node = Node, Options = unknown> = (
-  node: Tree,
-  file: VFile,
-  options: Options
-) => Promise<Tree | undefined | void> | Tree | undefined | void
-
-export {Severity, Label} from './lib/index.js'
+export {Label, Rule, Severity} from './lib/index.js'

--- a/packages/unified-lint-rule/lib/index.js
+++ b/packages/unified-lint-rule/lib/index.js
@@ -4,24 +4,29 @@
  *
  * @typedef {0|1|2} Severity
  * @typedef {'warn'|'on'|'off'|'error'} Label
- * @typedef {[Severity, ...Array<unknown>]} SeverityTuple
  *
  * @typedef RuleMeta
  * @property {string} origin name of the lint rule
  * @property {string} [url] link to documentation
- *
+ */
+
+/**
+ * @template {Node} Tree
+ * @template Options
  * @callback Rule
- * @param {Node} tree
+ * @param {Tree} tree
  * @param {VFile} file
- * @param {unknown} options
+ * @param {Options} options
  * @returns {void}
  */
 
 import {wrap} from 'trough'
 
 /**
+ * @template {Node} Tree
+ * @template Options
  * @param {string|RuleMeta} meta
- * @param {Rule} rule
+ * @param {Rule<Tree, Options>} rule
  */
 export function lintRule(meta, rule) {
   const id = typeof meta === 'string' ? meta : meta.origin
@@ -36,7 +41,7 @@ export function lintRule(meta, rule) {
 
   return plugin
 
-  /** @type {import('unified').Plugin<[unknown]|Array<void>>} */
+  /** @type {import('unified').Plugin<Array<void>|[Options|[boolean|Label|Severity, (Options|undefined)?]]>} */
   function plugin(config) {
     const [severity, options] = coerce(ruleId, config)
 
@@ -73,29 +78,29 @@ export function lintRule(meta, rule) {
 /**
  * Coerce a value to a severity--options tuple.
  *
+ * @template Options
  * @param {string} name
- * @param {unknown} config
- * @returns {SeverityTuple}
+ * @param {Options|[boolean|Label|Severity, (Options|undefined)?]} config
+ * @returns {[Severity, Options|undefined]}
  */
 function coerce(name, config) {
   if (!Array.isArray(config)) return [1, config]
-  /** @type {Array<unknown>} */
-  const [severity, ...options] = config
+  const [severity, options] = config
   switch (severity) {
     case false:
     case 'off':
     case 0:
-      return [0, ...options]
+      return [0, options]
     case true:
     case 'on':
     case 'warn':
     case 1:
-      return [1, ...options]
+      return [1, options]
     case 'error':
     case 2:
-      return [2, ...options]
+      return [2, options]
     default:
-      if (typeof severity !== 'number') return [1, config]
+      if (typeof severity !== 'number') return [1, /** @type {never} */ (config)]
       throw new Error(
         'Incorrect severity `' +
           severity +


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

What do you think about narrowing the `coerce()` return type from `unknown` to a type parameter, which is less permissive?

What I did was:
- Change the return type from `[Severity, ...Array<unknown>]` to `[Severity, Options|undefined]`
- Change the parameter type from `unknown` to `Options|[boolean|Label|Severity, (Options|undefined)?]`
- Include the `Options` type parameter in the `Rule` type

<!--do not edit: pr-->
