### PR TITLE
no-undefined-references: add support for regex as option

### DIFF
--- a/packages/remark-lint-no-undefined-references/index.js
+++ b/packages/remark-lint-no-undefined-references/index.js
@@ -153,14 +153,14 @@ const remarkLintNoUndefinedReferences = lintRule(
 
     const allow = option.allow || []
     /** @type {Array<RegExp>} */
-    const regexes = [];
+    const regexes = []
     /** @type {Set<string>} */
     const strings = new Set()
 
-    let index = -1;
+    let index = -1
 
     while (++index < allow.length) {
-      const value = allow[index];
+      const value = allow[index]
       if (typeof value === 'string') {
         strings.add(normalizeIdentifier(value))
       } else if (value instanceof RegExp) {

--- a/packages/remark-lint-no-undefined-references/index.js
+++ b/packages/remark-lint-no-undefined-references/index.js
@@ -125,10 +125,8 @@
  * @typedef {import('mdast').Heading} Heading
  * @typedef {import('mdast').Paragraph} Paragraph
  *
- * @typedef {Array<string | RegExp | { source: string }>} Allow
- *
  * @typedef Options
- * @property {Allow} [allow]
+ * @property {Array<string | RegExp | { source: string }>} [allow]
  *
  * @typedef {Array<number>} Range
  */

--- a/packages/remark-lint-no-undefined-references/index.js
+++ b/packages/remark-lint-no-undefined-references/index.js
@@ -13,7 +13,7 @@
  *         — text or regex that you want to be allowed between `[` and `]`
  *         even though it’s undefined; regex is provided via a `RegExp` object
  *         or via a `{ source: string }` object where `source` is the source
- *         text of a case-insensitive regex object
+ *         text of a case-insensitive regex
  *
  * ## Recommendation
  *

--- a/packages/remark-lint-no-undefined-references/index.js
+++ b/packages/remark-lint-no-undefined-references/index.js
@@ -103,6 +103,19 @@
  *   15:13-15:25: Found reference to undefined definition
  *   17:17-17:23: Found reference to undefined definition
  *   17:23-17:26: Found reference to undefined definition
+ *
+ * @example
+ *   {"name": "not-ok.md", "label": "input", "config": {"allow": ["a", {"source": "^b\\."}]}}
+ *
+ *   [foo][a.c]
+ *
+ *   [bar][b]
+ *
+ * @example
+ *   {"name": "not-ok.md", "label": "output", "config": {"allow": ["a", {"source": "^b\\."}]}}
+ *
+ *   1:1-1:11: Found reference to undefined definition
+ *   3:1-3:9: Found reference to undefined definition
  */
 
 /**

--- a/packages/remark-lint-no-undefined-references/index.js
+++ b/packages/remark-lint-no-undefined-references/index.js
@@ -62,15 +62,13 @@
  *   > Eliding a portion of a quoted passage […] is acceptable.
  *
  * @example
- *   {"name": "ok-allow.md", "config": {"allow": ["a", {"source": "^pkg\\."}, "b"]}}
+ *   {"name": "ok-allow.md", "config": {"allow": ["a", {"source": "^b\\."}]}}
  *
- *   [foo][pkg.subpkg]
+ *   [foo][b.c]
  *
  *   [bar][a]
  *
- *   [baz][b]
- *
- *   Matching is case-insensitive: [bar][PKG.SUBPKG]
+ *   Matching is case-insensitive: [bar][B.C]
  *
  * @example
  *   {"name": "not-ok.md", "label": "input"}

--- a/packages/remark-lint-no-undefined-references/index.js
+++ b/packages/remark-lint-no-undefined-references/index.js
@@ -358,13 +358,11 @@ const remarkLintNoUndefinedReferences = lintRule(
      * @returns {boolean}
      */
     function isAllowed(id) {
-      if (strings.size > 0 && strings.has(normalizeIdentifier(id))) {
-        return true
-      }
-      if (regexes.some((regex) => regex.test(id))) {
-        return true
-      }
-      return false
+      const normalized = normalizeIdentifier(id)
+      return (
+        strings.has(normalized) ||
+        regexes.some((regex) => regex.test(normalized))
+      )
     }
   }
 )

--- a/packages/remark-lint-no-undefined-references/index.js
+++ b/packages/remark-lint-no-undefined-references/index.js
@@ -10,8 +10,10 @@
  * *   `Object` with the following fields:
  *     *   `allow` (`Array<string | RegExp | { source: string }>`,
  *         default: `[]`)
- *         — text or a regex that you want to be allowed between `[` and `]`
- *         even though it’s undefined
+ *         — text or regex that you want to be allowed between `[` and `]`
+ *         even though it’s undefined; regex is provided via a `RegExp` object
+ *         or via a `{ source: string }` object where `source` is the source
+ *         text of a case-insensitive regex object
  *
  * ## Recommendation
  *

--- a/packages/remark-lint-no-undefined-references/readme.md
+++ b/packages/remark-lint-no-undefined-references/readme.md
@@ -127,8 +127,10 @@ The following options (default: `undefined`) are accepted:
 *   `Object` with the following fields:
     *   `allow` (`Array<string | RegExp | { source: string }>`,
         default: `[]`)
-        — text or a regex that you want to be allowed between `[` and `]`
-        even though it’s undefined
+        — text or regex that you want to be allowed between `[` and `]`
+        even though it’s undefined; regex is provided via a `RegExp` object
+        or via a `{ source: string }` object where `source` is the source
+        text of a case-insensitive regex object
 
 ## Recommendation
 

--- a/packages/remark-lint-no-undefined-references/readme.md
+++ b/packages/remark-lint-no-undefined-references/readme.md
@@ -125,9 +125,10 @@ This rule supports standard configuration that all remark lint rules accept
 The following options (default: `undefined`) are accepted:
 
 *   `Object` with the following fields:
-    *   `allow` (`Array<string>`, default: `[]`)
-        — text that you want to allowed between `[` and `]` even though it’s
-        undefined
+    *   `allow` (`Array<string | RegExp | { source: string }>`,
+        default: `[]`)
+        — text or a regex that you want to be allowed between `[` and `]`
+        even though it’s undefined
 
 ## Recommendation
 
@@ -221,6 +222,26 @@ When configured with `{ allow: [ '...', '…' ] }`.
 
 ```markdown
 > Eliding a portion of a quoted passage […] is acceptable.
+```
+
+###### Out
+
+No messages.
+
+##### `ok-allow.md`
+
+When configured with `{ allow: [ 'a', { source: '^pkg\\.' }, 'b' ] }`.
+
+###### In
+
+```markdown
+[foo][pkg.subpkg]
+
+[bar][a]
+
+[baz][b]
+
+Matching is case-insensitive: [bar][PKG.SUBPKG]
 ```
 
 ###### Out

--- a/packages/remark-lint-no-undefined-references/readme.md
+++ b/packages/remark-lint-no-undefined-references/readme.md
@@ -230,18 +230,16 @@ No messages.
 
 ##### `ok-allow.md`
 
-When configured with `{ allow: [ 'a', { source: '^pkg\\.' }, 'b' ] }`.
+When configured with `{ allow: [ 'a', { source: '^b\\.' } ] }`.
 
 ###### In
 
 ```markdown
-[foo][pkg.subpkg]
+[foo][b.c]
 
 [bar][a]
 
-[baz][b]
-
-Matching is case-insensitive: [bar][PKG.SUBPKG]
+Matching is case-insensitive: [bar][B.C]
 ```
 
 ###### Out

--- a/packages/remark-lint-no-undefined-references/readme.md
+++ b/packages/remark-lint-no-undefined-references/readme.md
@@ -130,7 +130,7 @@ The following options (default: `undefined`) are accepted:
         — text or regex that you want to be allowed between `[` and `]`
         even though it’s undefined; regex is provided via a `RegExp` object
         or via a `{ source: string }` object where `source` is the source
-        text of a case-insensitive regex object
+        text of a case-insensitive regex
 
 ## Recommendation
 

--- a/packages/remark-lint-no-undefined-references/readme.md
+++ b/packages/remark-lint-no-undefined-references/readme.md
@@ -246,6 +246,25 @@ Matching is case-insensitive: [bar][B.C]
 
 No messages.
 
+##### `not-ok.md`
+
+When configured with `{ allow: [ 'a', { source: '^b\\.' } ] }`.
+
+###### In
+
+```markdown
+[foo][a.c]
+
+[bar][b]
+```
+
+###### Out
+
+```text
+1:1-1:11: Found reference to undefined definition
+3:1-3:9: Found reference to undefined definition
+```
+
 ## Compatibility
 
 Projects maintained by the unified collective are compatible with all maintained

--- a/test.js
+++ b/test.js
@@ -21,6 +21,7 @@ import {characters} from './script/characters.js'
 import lint from './packages/remark-lint/index.js'
 import noHeadingPunctuation from './packages/remark-lint-no-heading-punctuation/index.js'
 import noMultipleToplevelHeadings from './packages/remark-lint-no-multiple-toplevel-headings/index.js'
+import noUndefinedReferences from './packages/remark-lint-no-undefined-references/index.js'
 import finalNewline from './packages/remark-lint-final-newline/index.js'
 
 const own = {}.hasOwnProperty
@@ -224,6 +225,21 @@ test('core', async (t) => {
     },
     /^Error: Incorrect severity `-1` for `final-newline`, expected 0, 1, or 2$/,
     'should fail on incorrect severities (too low)'
+  )
+
+  file = await remark()
+    .use(noUndefinedReferences, {allow: [/^b\./i]})
+    .process(
+      toVFile({
+        path: 'virtual.md',
+        value: ['[foo][b.c]', '', '[bar][b]'].join('\n')
+      })
+    )
+
+  t.deepEqual(
+    asStrings(file.messages),
+    ['virtual.md:3:1-3:9: Found reference to undefined definition'],
+    'no-undefined-references allow option should work with native regex'
   )
 
   file = await remark()


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

I've added support for regex patterns in the `allow` option in the [`no-undefined-references`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-undefined-references) rule.

Let me know what you think. :slightly_smiling_face:

Closes #296.

<!--do not edit: pr-->
