### PR TITLE
no-empty-url: consider urls from definition nodes

### DIFF
--- a/packages/remark-lint-no-empty-url/index.js
+++ b/packages/remark-lint-no-empty-url/index.js
@@ -26,6 +26,10 @@
  *
  *   ![charlie](http://delta.com/echo.png "foxtrot").
  *
+ *   [zulu][yankee].
+ *
+ *   [yankee]: http://xray.com
+ *
  * @example
  *   {"name": "not-ok.md", "label": "input"}
  *
@@ -33,11 +37,16 @@
  *
  *   ![hotel]().
  *
+ *   [zulu][yankee].
+ *
+ *   [yankee]: <>
+ *
  * @example
  *   {"name": "not-ok.md", "label": "output"}
  *
  *   1:1-1:9: Don’t use links without URL
  *   3:1-3:11: Don’t use images without URL
+ *   7:1-7:13: Don’t use definitions without URL
  */
 
 /**
@@ -57,7 +66,9 @@ const remarkLintNoEmptyUrl = lintRule(
   (tree, file) => {
     visit(tree, (node) => {
       if (
-        (node.type === 'link' || node.type === 'image') &&
+        (node.type === 'link' ||
+          node.type === 'image' ||
+          node.type === 'definition') &&
         !generated(node) &&
         !node.url
       ) {

--- a/packages/remark-lint-no-empty-url/readme.md
+++ b/packages/remark-lint-no-empty-url/readme.md
@@ -136,6 +136,10 @@ It’s recommended to fill them out.
 [alpha](http://bravo.com).
 
 ![charlie](http://delta.com/echo.png "foxtrot").
+
+[zulu][yankee].
+
+[yankee]: http://xray.com
 ```
 
 ###### Out
@@ -150,6 +154,10 @@ No messages.
 [golf]().
 
 ![hotel]().
+
+[zulu][yankee].
+
+[yankee]: <>
 ```
 
 ###### Out
@@ -157,6 +165,7 @@ No messages.
 ```text
 1:1-1:9: Don’t use links without URL
 3:1-3:11: Don’t use images without URL
+7:1-7:13: Don’t use definitions without URL
 ```
 
 ## Compatibility


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

First, thank you for remark and the unified ecosystem!

This is a small fix to allow [remark-lint-no-empty-url](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-empty-url) to also consider the URLs of `Definition` nodes when linting. When I first used this rule, I assumed that, because of the name, it would apply to _all_ URLs. However, after using [remark-reference-links](https://github.com/remarkjs/remark-reference-links), any mistakenly empty URLs normally caught by this rule were transformed into mistakenly empty definitions that were no longer caught by this rule, which came as a surprise to me.

Along with updated tests and documentation, I'm currently using [my forked version](https://github.com/xunnamius/remark-lint) across several projects if you want to test it out real quick:

```shell
npm install --save-dev https://xunn.at/remark-lint-no-empty-url
npx remark -o --no-config --use remark-lint-no-empty-url file-with-empty-definition.md
```

<!--do not edit: pr-->
