### PR TITLE
Fix `this` type in TS 4.9

### DIFF
--- a/packages/remark-lint/index.js
+++ b/packages/remark-lint/index.js
@@ -9,6 +9,7 @@ import remarkMessageControl from 'remark-message-control'
  * This adds support for ignoring stuff from messages (`<!--lint ignore-->`).
  * All rules are in their own packages and presets.
  *
+ * @this {import('unified').Processor}
  * @type {import('unified').Plugin<Array<void>, Root>}
  */
 export default function remarkLint() {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

fix `this` typing in TS4.9

<!--do not edit: pr-->
