### PR TITLE
types: resolve typings with node16 esm mode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,6 @@ The rules that are maintained here:
 *   [`remark-lint-definition-spacing`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-definition-spacing) — warn when consecutive whitespace is used in a definition
 *   [`remark-lint-emphasis-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-emphasis-marker) — warn when emphasis markers violate the given style
 *   [`remark-lint-fenced-code-flag`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-fenced-code-flag) — warn when fenced code blocks occur without language flag
-*   [`remark-lint-fenced-code-flag-case`](https://github.com/Xunnamius/unified-utils/blob/main/packages/remark-lint-fenced-code-flag-case) — warn when fenced code blocks have improperly cased language flags
 *   [`remark-lint-fenced-code-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-fenced-code-marker) — warn when fenced code markers violate the given style
 *   [`remark-lint-file-extension`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-file-extension) — warn when the file’s extension violates the given style
 *   [`remark-lint-final-definition`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-final-definition) — warn when definitions are not placed at the end of the file
@@ -120,14 +119,12 @@ The rules that are maintained here:
 *   [`remark-lint-hard-break-spaces`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-hard-break-spaces) — warn when too many spaces are used to create a hard break
 *   [`remark-lint-heading-increment`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-heading-increment) — warn when headings increment with more than 1 level at a time
 *   [`remark-lint-heading-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-heading-style) — warn when heading style violates the given style
-*   [`remark-lint-heading-word-length`](https://github.com/Xunnamius/unified-utils/tree/main/packages/remark-lint-heading-word-length) — warn when headings have too many or too few words with unicode support
 *   [`remark-lint-linebreak-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-linebreak-style) — warn when linebreaks violate a given or detected style
 *   [`remark-lint-link-title-style`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-link-title-style) — warn when link and definition titles occur with incorrect quotes
 *   [`remark-lint-list-item-bullet-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-bullet-indent) — warn when list item bullets are indented
 *   [`remark-lint-list-item-content-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-content-indent) — warn when the content of a list item has mixed indentation
 *   [`remark-lint-list-item-indent`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-indent) — warn when the spacing between a list item’s bullet and its content violates a given style
 *   [`remark-lint-list-item-spacing`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-spacing) — warn when list looseness is incorrect
-*   [`remark-lint-list-item-style`](https://github.com/Xunnamius/unified-utils/blob/main/packages/remark-lint-list-item-style) — warn when list items violate a given capitalization or punctuation style
 *   [`remark-lint-maximum-heading-length`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-maximum-heading-length) — warn when headings are too long
 *   [`remark-lint-maximum-line-length`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-maximum-line-length) — warn when lines are too long
 *   [`remark-lint-no-blockquote-without-marker`](https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-no-blockquote-without-marker) — warn when blank lines without markers (\`>\`) are found in a block quote

--- a/script/build-presets.js
+++ b/script/build-presets.js
@@ -39,6 +39,7 @@ presets(root).then((presetObjects) => {
     const doc = fs.readFileSync(path.join(base, 'index.js'), 'utf8')
     const fileInfo = parse(doc, {spacing: 'preserve'})[0]
     const tags = fileInfo.tags
+    // @ts-expect-error comment-parse types cannot be resolved by ESM, see https://github.com/syavorsky/comment-parser/issues/159 and https://github.com/syavorsky/comment-parser/pull/161
     const summaryTag = tags.find((d) => d.tag === 'summary')
     const author =
       typeof pack.author === 'string' ? parseAuthor(pack.author) : pack.author

--- a/script/util/rule.js
+++ b/script/util/rule.js
@@ -34,8 +34,11 @@ export function rule(filePath) {
   const code = fs.readFileSync(path.join(filePath, 'index.js'), 'utf8')
   const fileInfo = parse(code, {spacing: 'preserve'})[0]
   const tags = fileInfo.tags
+  // @ts-expect-error comment-parse types cannot be resolved by ESM, see https://github.com/syavorsky/comment-parser/issues/159 and https://github.com/syavorsky/comment-parser/pull/161
   const moduleTag = tags.find((d) => d.tag === 'module')
+  // @ts-expect-error comment-parse types cannot be resolved by ESM, see https://github.com/syavorsky/comment-parser/issues/159 and https://github.com/syavorsky/comment-parser/pull/161
   const summaryTag = tags.find((d) => d.tag === 'summary')
+  // @ts-expect-error comment-parse types cannot be resolved by ESM, see https://github.com/syavorsky/comment-parser/issues/159 and https://github.com/syavorsky/comment-parser/pull/161
   const deprecatedTag = tags.find((d) => d.tag === 'deprecated')
 
   /* c8 ignore next 3 */
@@ -70,7 +73,9 @@ export function rule(filePath) {
   }
 
   const examples = tags
+    // @ts-expect-error comment-parse types cannot be resolved by ESM, see https://github.com/syavorsky/comment-parser/issues/159 and https://github.com/syavorsky/comment-parser/pull/161
     .filter((d) => d.tag === 'example')
+    // @ts-expect-error comment-parse types cannot be resolved by ESM, see https://github.com/syavorsky/comment-parser/issues/159 and https://github.com/syavorsky/comment-parser/pull/161
     .map((d) => d.description.replace(/^\r?\n|\r?\n$/g, ''))
   let index = -1
 

--- a/test.js
+++ b/test.js
@@ -2,8 +2,8 @@
  * @typedef {import('unified').Plugin} Plugin
  * @typedef {import('vfile-message').VFileMessage} VFileMessage
  * @typedef {import('tape').Test} Test
- * @typedef {import('./script/util/rule').Rule} Rule
- * @typedef {import('./script/util/rule').Check} Check
+ * @typedef {import('./script/util/rule.js').Rule} Rule
+ * @typedef {import('./script/util/rule.js').Check} Check
  */
 
 import url from 'node:url'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,13 @@
 {
   "include": ["script/**/*.js", "test.js"],
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["ES2020"],
-    "module": "ES2020",
-    "moduleResolution": "node",
+    "target": "es2021",
+    "lib": ["es2021"],
+    "module": "node16",
     "resolveJsonModule": true,
-    "allowJs": true,
     "checkJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
-    "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "strict": true
   }


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This PR includes:

- [x] automatic style changes in _readme.md_ files
- [x] migrate to `node16` mode for module resolution
- [x] add `.js` extension where required by `node16` mode
- [ ] resolve broken typings in `comment-parser` (https://github.com/syavorsky/comment-parser/issues/159) there is a PR in the works https://github.com/syavorsky/comment-parser/issues/161 which resolves some of the issue, but doesn't completely solve the issue, some follow up may be needed
- [x] Figure out why table of contents are not generating


<!--do not edit: pr-->