### PR TITLE
maximum-line-length: fix long links

### DIFF
--- a/packages/remark-lint-maximum-line-length/index.js
+++ b/packages/remark-lint-maximum-line-length/index.js
@@ -60,6 +60,10 @@
  *
  *   <div>Mercury mercury mercury mercury mercury mercury mercury mercury mercury</div>
  *
+ *   Mercury
+ *   <http://localhost/mercury/mercury/mercury/mercury/mercury/mercury/mercury/mercury>
+ *   mercury mercury.
+ *
  *   [foo]: http://localhost/mercury/mercury/mercury/mercury/mercury/mercury/mercury/mercury
  *
  * @example
@@ -238,12 +242,15 @@ const remarkLintMaximumLineLength = lintRule(
 
           const next = parent.children[index + 1]
           const nextStart = pointStart(next)
+          const nextEnd = pointEnd(next)
 
           // Not allowing when there’s a following child.
           if (
             next &&
             nextStart &&
             nextStart.line === start.line &&
+            nextEnd &&
+            nextEnd.line === start.line &&
             // Either something with children:
             (!('value' in next) ||
               // Or with whitespace:

--- a/packages/remark-lint-maximum-line-length/readme.md
+++ b/packages/remark-lint-maximum-line-length/readme.md
@@ -165,6 +165,10 @@ Mercury mercury mercury mercury mercury mercury mercury mercury mercury ![mercur
 
 <div>Mercury mercury mercury mercury mercury mercury mercury mercury mercury</div>
 
+Mercury
+<http://localhost/mercury/mercury/mercury/mercury/mercury/mercury/mercury/mercury>
+mercury mercury.
+
 [foo]: http://localhost/mercury/mercury/mercury/mercury/mercury/mercury/mercury/mercury
 ```
 


### PR DESCRIPTION
Fixes: https://github.com/remarkjs/remark-lint/issues/318

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Fixes maximum line length calculation bug in https://github.com/remarkjs/remark-lint/issues/318.

<!--do not edit: pr-->
