### PR TITLE
Fix type errors

### DIFF
--- a/packages/unified-lint-rule/index.js
+++ b/packages/unified-lint-rule/index.js
@@ -134,7 +134,7 @@
 /**
  * @template {Node} [Tree=Node]
  *   Node kind (optional).
- * @template {any} [Option=unknown]
+ * @template {any} [Options=unknown]
  *   Parameter kind (optional).
  * @callback Rule
  *   Rule.
@@ -142,7 +142,7 @@
  *   Tree.
  * @param {import('vfile').VFile} file
  *   File.
- * @param {Option} option
+ * @param {Options} option
  *   Parameter.
  * @returns {Promise<undefined | void> | undefined | void}
  *   Nothing.

--- a/packages/unified-lint-rule/index.js
+++ b/packages/unified-lint-rule/index.js
@@ -111,15 +111,41 @@
  */
 
 /**
- * @typedef {import('./lib/index.js').Label} Label
- * @typedef {import('./lib/index.js').Meta} Meta
- * @typedef {import('./lib/index.js').Severity} Severity
+ * @typedef {'error' | 'on' | 'off' | 'warn' | boolean} Label
+ *   Severity label;
+ *   `'off'`: `0`, `'on'` and `warn`: `1`, `'error'`: `2`.
+ */
+
+/**
+ * @typedef Meta
+ *   Rule metadata.
+ * @property {string} origin
+ *   Name of the lint rule.
+ * @property {string | null | undefined} [url]
+ *   Link to documentation (optional).
+ */
+
+/**
+ * @typedef {0 | 1 | 2} Severity
+ *   Severity number;
+ *   `0`: `'off'`, `1`: `'on'` and `warn`, `2`: `'error'`.
  */
 
 /**
  * @template {Node} [Tree=Node]
- * @template {any} [Options=unknown]
- * @typedef {import('./lib/index.js').Rule<Tree, Options>} Rule
+ *   Node kind (optional).
+ * @template {any} [Option=unknown]
+ *   Parameter kind (optional).
+ * @callback Rule
+ *   Rule.
+ * @param {Tree} tree
+ *   Tree.
+ * @param {import('vfile').VFile} file
+ *   File.
+ * @param {Option} option
+ *   Parameter.
+ * @returns {Promise<undefined | void> | undefined | void}
+ *   Nothing.
  */
 
 export {lintRule} from './lib/index.js'

--- a/packages/unified-lint-rule/lib/index.js
+++ b/packages/unified-lint-rule/lib/index.js
@@ -3,7 +3,7 @@
  */
 
 /**
- * @typedef {[severity: import('../index.js').Severity, ...parameters: Array<unknown>]} SeverityTuple
+ * @typedef {[severity: import('unified-lint-rule').Severity, ...parameters: Array<unknown>]} SeverityTuple
  *   Parsed severty and options.
  */
 
@@ -14,15 +14,15 @@ import {wrap} from 'trough'
  *   Node kind.
  * @template {any} [Option=never]
  *   Parameter kind.
- * @param {import('../index.js').Meta | string} meta
+ * @param {import('unified-lint-rule').Meta | string} meta
  *   Info.
- * @param {import('../index.js').Rule<Tree, Option>} rule
+ * @param {import('unified-lint-rule').Rule<Tree, Option>} rule
  *   Rule.
  * @returns {import('unified').Plugin<[(
- *   | [level: import('../index.js').Label | import('../index.js').Severity, option?: Option]
- *   | import('../index.js').Label
+ *   | [level: import('unified-lint-rule').Label | import('unified-lint-rule').Severity, option?: Option]
+ *   | import('unified-lint-rule').Label
  *   | Option
- *   | import('../index.js').Severity
+ *   | import('unified-lint-rule').Severity
  * )?], Tree>}
  *   Plugin.
  */
@@ -40,7 +40,7 @@ export function lintRule(meta, rule) {
   return plugin
 
   /**
-   * @param {[level: import('../index.js').Label | import('../index.js').Severity, option?: Option] | import('../index.js').Label | Option | import('../index.js').Severity} [config]
+   * @param {[level: import('unified-lint-rule').Label | import('unified-lint-rule').Severity, option?: Option] | import('unified-lint-rule').Label | Option | import('unified-lint-rule').Severity} [config]
    *   Config.
    * @returns {import('unified').Transformer<Tree> | undefined}
    *   Transform, if on.

--- a/test.js
+++ b/test.js
@@ -232,6 +232,7 @@ test('remark-lint', async function (t) {
     'should fail on incorrect severities (too high)',
     async function () {
       assert.throws(function () {
+        // @ts-expect-error This tests an incorrect severity.
         remark().use(remarkLintFinalNewline, [3]).freeze()
       }, /^Error: Incorrect severity `3` for `final-newline`, expected 0, 1, or 2$/)
     }
@@ -241,6 +242,7 @@ test('remark-lint', async function (t) {
     'should fail on incorrect severities (too low)',
     async function () {
       assert.throws(function () {
+        // @ts-expect-error This tests an incorrect severity.
         remark().use(remarkLintFinalNewline, [-1]).freeze()
       }, /^Error: Incorrect severity `-1` for `final-newline`, expected 0, 1, or 2$/)
     }


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Since typical usage of `unified-lint-rule` involves inferring the type based on a function call, the inferred type should be public. If private types are used, TypeScript will generate types for dependant packages that use relative paths.

To solve this, public types in `unified-lint-rule` were moved from `lib/index.js` to `index.js`. `lintRule` only uses these public types.

The severity can be set as a boolean. To support this, the `Label` type now accepts a boolean type.

Two tests explicitly test bad input. These are annotated with a `@ts-expect-error` comment.

<!--do not edit: pr-->
