### PR TITLE
`remark-lint-no-unused-definitions`: Switch `unist-util-visit` dependency to `unist-util-visit-parents`

### DIFF
--- a/packages/remark-lint-no-unused-definitions/package.json
+++ b/packages/remark-lint-no-unused-definitions/package.json
@@ -8,7 +8,7 @@
     "@types/mdast": "^4.0.0",
     "devlop": "^1.0.0",
     "unified-lint-rule": "^3.0.0",
-    "unist-util-visit": "^5.0.0"
+    "unist-util-visit-parents": "^6.0.0"
   },
   "description": "remark-lint rule to warn when unused definitions are found",
   "exports": "./index.js",


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [X] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [X] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [X] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [X] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [X] I made sure the docs are up to date
* [X] I included tests (or that’s not needed)

### Description of changes

Fixes #327, see this issue for more details.

<!--do not edit: pr-->
