### PR TITLE
README: Add community plugin `remark-lint-word-case`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -258,6 +258,8 @@ The following rules are maintained by the community:
   — ensures there are spaces around number and Chinese.
 * [`remark-lint-spaces-around-word`](https://github.com/laysent/remark-lint-plugins/tree/HEAD/packages/remark-lint-spaces-around-word)
   — ensures there are spaces around English word and Chinese.
+* [`remark-lint-word-case`](https://github.com/Bugg4/remark-lint-word-case)
+  — enforces the specified casing on a list of user-defined words.
 * [`remark-lint-write-good`](https://github.com/zerok/remark-lint-write-good)
   — wrapper for `write-good`
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

This adds a new community maintained plugin to the list: [`remark-lint-word-case`](https://github.com/Bugg4/remark-lint-word-case).
This plugin accepts a list of words, such as ["JavaScript", "TypeScript"] and ensures that they appear with the specified casing, throwing an error if they don't.
Eg: "javascript" or "Javascript" would both throw an error, and they'd be corrected to "JavaScript".

<!--do not edit: pr-->
