### PR TITLE
heading-increment, no-multiple-toplevel-headings: fix typo in message

### DIFF
--- a/packages/remark-lint-heading-increment/index.js
+++ b/packages/remark-lint-heading-increment/index.js
@@ -77,9 +77,9 @@
  * @example
  *   {"label": "output", "name": "not-ok.md"}
  *
- *   3:1-3:23: Unexpected heading rank `3`, exected rank `2`
- *   5:1-5:20: Unexpected heading rank `3`, exected rank `2`
- *   9:1-9:16: Unexpected heading rank `4`, exected rank `3`
+ *   3:1-3:23: Unexpected heading rank `3`, expected rank `2`
+ *   5:1-5:20: Unexpected heading rank `3`, expected rank `2`
+ *   9:1-9:16: Unexpected heading rank `4`, expected rank `3`
  *
  * @example
  *   {"label": "input", "name": "html.md"}
@@ -95,7 +95,7 @@
  * @example
  *   {"label": "output", "name": "html.md"}
  *
- *   6:1-6:28: Unexpected heading rank `3`, exected rank `2`
+ *   6:1-6:28: Unexpected heading rank `3`, expected rank `2`
  *
  * @example
  *   {"mdx": true, "name": "mdx.mdx"}
@@ -111,7 +111,7 @@
  * @example
  *   {"label": "output", "mdx": true, "name": "mdx.mdx"}
  *
- *   6:1-6:28: Unexpected heading rank `3`, exected rank `2`
+ *   6:1-6:28: Unexpected heading rank `3`, expected rank `2`
  */
 
 /**
@@ -167,7 +167,7 @@ const remarkLintHeadingIncrement = lintRule(
             file.message(
               'Unexpected heading rank `' +
                 rank +
-                '`, exected rank `' +
+                '`, expected rank `' +
                 (parentRank + 1) +
                 '`',
               {

--- a/packages/remark-lint-heading-increment/readme.md
+++ b/packages/remark-lint-heading-increment/readme.md
@@ -197,9 +197,9 @@ No messages.
 ###### Out
 
 ```text
-3:1-3:23: Unexpected heading rank `3`, exected rank `2`
-5:1-5:20: Unexpected heading rank `3`, exected rank `2`
-9:1-9:16: Unexpected heading rank `4`, exected rank `3`
+3:1-3:23: Unexpected heading rank `3`, expected rank `2`
+5:1-5:20: Unexpected heading rank `3`, expected rank `2`
+9:1-9:16: Unexpected heading rank `4`, expected rank `3`
 ```
 
 ##### `html.md`
@@ -220,7 +220,7 @@ in the Solar System.
 ###### Out
 
 ```text
-6:1-6:28: Unexpected heading rank `3`, exected rank `2`
+6:1-6:28: Unexpected heading rank `3`, expected rank `2`
 ```
 
 ##### `mdx.mdx`
@@ -244,7 +244,7 @@ in the Solar System.
 ###### Out
 
 ```text
-6:1-6:28: Unexpected heading rank `3`, exected rank `2`
+6:1-6:28: Unexpected heading rank `3`, expected rank `2`
 ```
 
 ## Compatibility

--- a/packages/remark-lint-no-multiple-toplevel-headings/index.js
+++ b/packages/remark-lint-no-multiple-toplevel-headings/index.js
@@ -76,7 +76,7 @@
  * @example
  *   {"label": "output", "name": "not-ok.md"}
  *
- *   3:1-3:10: Unexpected duplicate toplevel heading, exected a single heading with rank `1`
+ *   3:1-3:10: Unexpected duplicate toplevel heading, expected a single heading with rank `1`
  *
  * @example
  *   {"config": 2, "label": "input", "name": "not-ok.md"}
@@ -87,7 +87,7 @@
  * @example
  *   {"config": 2, "label": "output", "name": "not-ok.md"}
  *
- *   3:1-3:11: Unexpected duplicate toplevel heading, exected a single heading with rank `2`
+ *   3:1-3:11: Unexpected duplicate toplevel heading, expected a single heading with rank `2`
  *
  * @example
  *   {"label": "input", "name": "html.md"}
@@ -100,7 +100,7 @@
  * @example
  *   {"label": "output", "name": "html.md"}
  *
- *   5:1-5:14: Unexpected duplicate toplevel heading, exected a single heading with rank `1`
+ *   5:1-5:14: Unexpected duplicate toplevel heading, expected a single heading with rank `1`
  *
  * @example
  *   {"label": "input", "mdx": true, "name": "mdx.mdx"}
@@ -112,7 +112,7 @@
  * @example
  *   {"label": "output", "mdx": true, "name": "mdx.mdx"}
  *
- *   4:1-4:14: Unexpected duplicate toplevel heading, exected a single heading with rank `1`
+ *   4:1-4:14: Unexpected duplicate toplevel heading, expected a single heading with rank `1`
  */
 
 /**
@@ -181,7 +181,7 @@ const remarkLintNoMultipleToplevelHeadings = lintRule(
             assert(duplicate) // Always defined.
 
             file.message(
-              'Unexpected duplicate toplevel heading, exected a single heading with rank `' +
+              'Unexpected duplicate toplevel heading, expected a single heading with rank `' +
                 rank +
                 '`',
               {

--- a/packages/remark-lint-no-multiple-toplevel-headings/readme.md
+++ b/packages/remark-lint-no-multiple-toplevel-headings/readme.md
@@ -191,7 +191,7 @@ No messages.
 ###### Out
 
 ```text
-3:1-3:10: Unexpected duplicate toplevel heading, exected a single heading with rank `1`
+3:1-3:10: Unexpected duplicate toplevel heading, expected a single heading with rank `1`
 ```
 
 ##### `not-ok.md`
@@ -209,7 +209,7 @@ When configured with `2`.
 ###### Out
 
 ```text
-3:1-3:11: Unexpected duplicate toplevel heading, exected a single heading with rank `2`
+3:1-3:11: Unexpected duplicate toplevel heading, expected a single heading with rank `2`
 ```
 
 ##### `html.md`
@@ -227,7 +227,7 @@ Venus <b>and</b> mercury.
 ###### Out
 
 ```text
-5:1-5:14: Unexpected duplicate toplevel heading, exected a single heading with rank `1`
+5:1-5:14: Unexpected duplicate toplevel heading, expected a single heading with rank `1`
 ```
 
 ##### `mdx.mdx`
@@ -247,7 +247,7 @@ Venus <b>and</b> mercury.
 ###### Out
 
 ```text
-4:1-4:14: Unexpected duplicate toplevel heading, exected a single heading with rank `1`
+4:1-4:14: Unexpected duplicate toplevel heading, expected a single heading with rank `1`
 ```
 
 ## Compatibility

--- a/test.js
+++ b/test.js
@@ -62,7 +62,7 @@ test('remark-lint', async function (t) {
 
     assert.deepEqual(file.messages.map(String), [
       'virtual.md:3:1-3:24: Unexpected character `.` at end of heading, remove it',
-      'virtual.md:3:1-3:24: Unexpected duplicate toplevel heading, exected a single heading with rank `1`'
+      'virtual.md:3:1-3:24: Unexpected duplicate toplevel heading, expected a single heading with rank `1`'
     ])
   })
 
@@ -75,7 +75,7 @@ test('remark-lint', async function (t) {
 
     assert.deepEqual(file.messages.map(String), [
       'virtual.md:3:1-3:24: Unexpected character `.` at end of heading, remove it',
-      'virtual.md:3:1-3:24: Unexpected duplicate toplevel heading, exected a single heading with rank `1`'
+      'virtual.md:3:1-3:24: Unexpected duplicate toplevel heading, expected a single heading with rank `1`'
     ])
   })
 


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up-to-date
* [x] I included tests (or that’s not needed)

### Description of changes

This commit fixes a typo in the lint message for unexpected heading ranks and in the associate JS Docs.

<!--do not edit: pr-->
